### PR TITLE
Refactor lock manager to ignore "ghost txns"

### DIFF
--- a/common/configuration.cpp
+++ b/common/configuration.cpp
@@ -36,6 +36,9 @@ ConfigurationPtr Configuration::FromFile(
     uint32_t local_replica,
     uint32_t local_partition) {
   int fd = open(file_path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    LOG(FATAL) << "Configuration file error: " << strerror(errno);
+  }
   ZeroCopyInputStream* input = new FileInputStream(fd);
   internal::Configuration config;
 

--- a/module/scheduler_components/deterministic_lock_manager.h
+++ b/module/scheduler_components/deterministic_lock_manager.h
@@ -3,6 +3,7 @@
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "common/configuration.h"
 #include "common/constants.h"
@@ -13,6 +14,7 @@ using std::shared_ptr;
 using std::pair;
 using std::unordered_map;
 using std::unordered_set;
+using std::vector;
 
 namespace slog {
 
@@ -91,6 +93,8 @@ public:
   unordered_set<TxnId> ReleaseLocks(const Transaction& txn);
 
 private:
+  vector<pair<Key, LockMode>> ExtractKeys(const Transaction& txn);
+
   ConfigurationPtr config_;
   unordered_map<Key, LockState> lock_table_;
   unordered_map<TxnId, int32_t> num_locks_waited_;

--- a/tools/fnv_hash.py
+++ b/tools/fnv_hash.py
@@ -1,0 +1,37 @@
+import sys
+if sys.version_info[0] == 3:
+    _get_byte = lambda c: c
+else:
+    _get_byte = ord
+
+from argparse import ArgumentParser
+
+
+def fnv_hash(value: bytes) -> int:
+    assert isinstance(value, bytes)
+
+    FNV_32_PRIME = 0x01000193
+    FNV_32_SIZE = 2**32
+
+    hash = 0x811c9dc5
+    for byte in value:
+        hash = (hash * FNV_32_PRIME) % FNV_32_SIZE
+        hash = hash ^ _get_byte(byte)
+    return hash
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        description="Computes FNV hash for a given string"
+    )
+    parser.add_argument("string", help="A string to compute FNV hash")
+    parser.add_argument(
+        "-m",
+        type=int,
+        help="The value to take modulo of the result by"
+    )
+    args = parser.parse_args()
+    result = fnv_hash(args.string.encode())
+    if args.m is not None:
+        result %= args.m
+    print(result)

--- a/tools/gen_data.py
+++ b/tools/gen_data.py
@@ -8,18 +8,16 @@ import logging
 import numpy as np
 import os
 import string
-import sys
-if sys.version_info[0] == 3:
-    _get_byte = lambda c: c
-else:
-    _get_byte = ord
 import time
 
 from argparse import ArgumentParser
 from collections import defaultdict
 from functools import partial
+
 from google.protobuf.internal.encoder import _VarintBytes
 from multiprocessing import Pool
+
+from fnv_hash import fnv_hash
 from proto.offline_data_pb2 import Datum
 
 ALPHABET = np.array(list(string.ascii_lowercase + string.digits))
@@ -48,19 +46,6 @@ def encode_key(key: int) -> bytes:
     return base64.b64encode(
         key.to_bytes(8, byteorder='little')
     )
-
-
-def fnv_hash(value: bytes) -> int:
-    assert isinstance(value, bytes)
-
-    FNV_32_PRIME = 0x01000193
-    FNV_32_SIZE = 2**32
-
-    hash = 0x811c9dc5
-    for byte in value:
-        hash = (hash * FNV_32_PRIME) % FNV_32_SIZE
-        hash = hash ^ _get_byte(byte)
-    return hash
 
 
 class DataGenerator:
@@ -202,7 +187,7 @@ class DataGenerator:
         
         return datum
 
-
+# TODO(ctring): Take into account number of bytes actually used for partitioning
 if __name__ == "__main__":
     parser = ArgumentParser(
         "gen_data",


### PR DESCRIPTION
The LockOnly txns are replicated everywhere so a partition might receive a "ghost txn" that do not have any key belonging to the partition. The `RegisterTxn` and `AcquireLocks` methods in the lock manager, while ignore these keys, still go on to check `num_locks_waited_[txn_id] == 0`, which is always true in this case if it is already 0 before that. This leads to these function returning true and make scheduler to dispatch a non-existent txn.
+ This patch addes a new method `ExtractKeys` to get all keys from a txn. Users of this method can know if a txn is a ghost txn if the returned key set is empty.
+ A tool is also added to quickly compute the hash of a value.
