### PR TITLE
Enqueue txns when we run out of workers

### DIFF
--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -72,7 +72,8 @@ private:
   void TryUpdatingLocalLog();
   void TryProcessingNextBatchesFromGlobalLog();
 
-  void DispatchTransaction(TxnId txn_id);
+  void EnqueueTransaction(TxnId txn_id);
+  void TryDispatchingNextTransaction();
 
   void SendToWorker(internal::Request&& req, const string& worker);
 
@@ -81,6 +82,7 @@ private:
   vector<zmq::pollitem_t> poll_items_;
   vector<unique_ptr<ModuleRunner>> workers_;
   queue<string> ready_workers_;
+  queue<TxnId> ready_txns_;
 
   unordered_map<uint32_t, BatchLog> all_logs_;
   BatchInterleaver local_interleaver_;

--- a/test/common/proto_utils_test.cpp
+++ b/test/common/proto_utils_test.cpp
@@ -14,16 +14,16 @@ TEST(ProtoUtilsTest, MachineIdStringToMachineId) {
   internal::MachineId mid;
 
   mid = MakeMachineId("0:0");
-  ASSERT_EQ(mid.replica(), 0);
-  ASSERT_EQ(mid.partition(), 0);
+  ASSERT_EQ(mid.replica(), 0U);
+  ASSERT_EQ(mid.partition(), 0U);
 
   mid = MakeMachineId("12:34");
-  ASSERT_EQ(mid.replica(), 12);
-  ASSERT_EQ(mid.partition(), 34);
+  ASSERT_EQ(mid.replica(), 12U);
+  ASSERT_EQ(mid.partition(), 34U);
 
   mid = MakeMachineId("5aa:6bb");
-  ASSERT_EQ(mid.replica(), 5);
-  ASSERT_EQ(mid.partition(), 6);
+  ASSERT_EQ(mid.replica(), 5U);
+  ASSERT_EQ(mid.partition(), 6U);
 
   ASSERT_THROW(MakeMachineId("01234"), std::invalid_argument);
   ASSERT_THROW(MakeMachineId("ab12:cd34"), std::invalid_argument);


### PR DESCRIPTION
There is no check on `ready_workers_` so we might pop an empty queue if all workers are busy. To avoid this, enqueue the txns in such situation and dequeue when we have free workers.