### PR TITLE
Travis install cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,14 @@ cache:
     - .deps
 
 before_install:
-  - cmake -version
+  - cd /tmp
+  - wget https://github.com/Kitware/CMake/releases/download/v3.12.4/cmake-3.12.4-Linux-x86_64.sh -O cmake-install.sh
+  - chmod u+x cmake-install.sh
+  - sudo ./cmake-install.sh --skip-license --prefix=/usr
+  - rm cmake-install.sh
 
 install:
+  - cd $TRAVIS_BUILD_DIR
   - sudo ./install-deps.sh
 
 script:

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -6,6 +6,7 @@ set -e
 # Install toolings to compile dependencies
 apt-get update
 apt-get -y install autoconf automake cmake libtool curl unzip libreadline-dev pkg-config wget || true
+cmake --version
 
 INSTALL_PREFIX=$PWD/.deps
 DOWNLOAD_DIR=$INSTALL_PREFIX/download

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -5,7 +5,7 @@ set -e
 
 # Install toolings to compile dependencies
 apt-get update
-apt-get -y install autoconf automake libtool curl unzip libreadline-dev pkg-config wget || true
+apt-get -y install autoconf automake cmake libtool curl unzip libreadline-dev pkg-config wget || true
 
 INSTALL_PREFIX=$PWD/.deps
 DOWNLOAD_DIR=$INSTALL_PREFIX/download

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -5,8 +5,7 @@ set -e
 
 # Install toolings to compile dependencies
 apt-get update
-apt-get -y install autoconf automake cmake libtool curl unzip libreadline-dev pkg-config wget || true
-cmake --version
+apt-get -y install autoconf automake libtool curl unzip libreadline-dev pkg-config wget || true
 
 INSTALL_PREFIX=$PWD/.deps
 DOWNLOAD_DIR=$INSTALL_PREFIX/download


### PR DESCRIPTION
Fix travis build.

It would be nice if we could remove the non-sudo preinstalled cmake, but not sure how. apt-get remove only works if it is sudo, and then it can't find cmake.