### PR TITLE
Improve benchmark tool and fix a bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,9 @@ target_link_libraries(slog
 
 add_executable(benchmark service/benchmark.cpp)
 target_link_libraries(benchmark 
-  workload
   common
-  offline_data_reader
+  ticker
+  workload
   ${EXTERNAL_LIBS})
 
 if (BUILD_CLIENT)

--- a/examples/simple_cluster.conf
+++ b/examples/simple_cluster.conf
@@ -1,9 +1,9 @@
 protocol: "tcp"
 replicas: {
-    addresses: "192.168.122.5"
+    addresses: "172.28.5.1"
 }
 replicas: {
-    addresses: "192.168.122.9"
+    addresses: "172.28.5.2"
 }
 broker_port: 2022
 server_port: 2023

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -27,3 +27,6 @@ target_link_libraries(module
   base_module
   paxos
   scheduler_components)
+
+add_library(ticker ticker.cpp)
+target_link_libraries(ticker base_module common)

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -25,7 +25,7 @@ using std::vector;
 namespace slog {
 
 struct TransactionHolder {
-  unique_ptr<Transaction> txn;
+  Transaction* txn;
   string worker;
   vector<internal::Request> early_remote_reads;
 };

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -4,6 +4,7 @@
 
 #include <zmq.hpp>
 
+#include "common/configuration.h"
 #include "common/types.h"
 #include "module/base/module.h"
 #include "module/scheduler_components/commands.h"
@@ -17,13 +18,11 @@ using std::unordered_set;
 
 namespace slog {
 
-class Scheduler;
-
 struct TransactionState {
 
-  TransactionState(TxnId txn_id) : txn_id(txn_id) {}
+  TransactionState(Transaction* txn) : txn(txn) {}
 
-  TxnId txn_id;
+  Transaction* txn;
   unordered_set<uint32_t> awaited_passive_participants;
   unordered_set<uint32_t> active_participants;
   unordered_set<uint32_t> participants;
@@ -32,7 +31,7 @@ struct TransactionState {
 class Worker : public Module {
 public:
   Worker(
-      Scheduler& scheduler,
+      ConfigurationPtr config,
       zmq::context_t& context,
       shared_ptr<Storage<Key, Record>> storage);
   void SetUp() final;
@@ -47,7 +46,7 @@ private:
       const google::protobuf::Message& req_or_res,
       string&& forward_to_machine = "");
 
-  Scheduler& scheduler_;
+  ConfigurationPtr config_;
   zmq::socket_t scheduler_socket_;
   shared_ptr<Storage<Key, Record>> storage_;
   unique_ptr<Commands> commands_;

--- a/module/ticker.cpp
+++ b/module/ticker.cpp
@@ -1,0 +1,24 @@
+#include "ticker.h"
+
+namespace slog {
+
+const string Ticker::ENDPOINT("inproc://ticker");
+
+Ticker::Ticker(zmq::context_t& context, uint32_t ticks_per_sec)
+    : socket_(context, ZMQ_PUB),
+      ticks_per_sec_(ticks_per_sec) {
+  socket_.setsockopt(ZMQ_LINGER, 0);
+  sleep_us_ = std::chrono::microseconds(1000 * 1000 / ticks_per_sec_);
+}
+
+void Ticker::SetUp() {
+  socket_.bind(ENDPOINT);
+}
+
+void Ticker::Loop() {
+  zmq::message_t msg;
+  socket_.send(msg, zmq::send_flags::dontwait);
+  std::this_thread::sleep_for(sleep_us_);
+}
+
+} // namespace slog

--- a/module/ticker.h
+++ b/module/ticker.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <zmq.hpp>
+
+#include "common/types.h"
+#include "module/base/module.h"
+
+namespace slog {
+
+class Ticker : public Module {
+public:
+  const static string ENDPOINT;
+
+  Ticker(zmq::context_t& context, uint32_t ticks_per_sec);
+
+  void SetUp() final;
+  void Loop() final;
+
+private:
+  zmq::socket_t socket_;
+  uint32_t ticks_per_sec_;
+  Duration sleep_us_;
+};
+
+} // slog

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -107,7 +107,7 @@ message LocalQueueOrder {
 }
 
 message ProcessTransactionRequest {
-    uint32 txn_id = 1;
+    uint64 txn_ptr = 1;
 }
 
 message RemoteReadResult {

--- a/workload/CMakeLists.txt
+++ b/workload/CMakeLists.txt
@@ -2,6 +2,6 @@ project(workload)
 
 add_library(workload basic_workload.cpp)
 target_link_libraries(workload
-  common
   module
+  offline_data_reader
   proto)


### PR DESCRIPTION
The bug was that worker and scheduler, on separate threads, access the non-thread-safe `all_txns_` map. It is unnecessary for the worker to have access to the entire map so now the scheduler only hands a pointer to the worker for access to the txn.