### PR TITLE
Bug fixes

### DIFF
--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -130,6 +130,7 @@ TransactionType SetTransactionType(Transaction& txn) {
   bool is_single_home = true;
   // If this is a single-home txn, home of all other keys must
   // be the same as that of the first key
+  // TODO: check and report empty transaction
   const auto& home_replica = master_metadata.begin()->second.master();
   for (const auto& pair : master_metadata) {
     if (pair.second.master() != home_replica) {

--- a/module/forwarder.cpp
+++ b/module/forwarder.cpp
@@ -128,13 +128,13 @@ void Forwarder::Forward(Transaction* txn) {
     // Otherwise, forward to the sequencer of a random machine in its home region
     auto home_replica = master_metadata.begin()->second.master();
     if (home_replica == config_->GetLocalReplica()) {
-      VLOG(2) << "Current region is home of txn " << txn_id;
+      VLOG(3) << "Current region is home of txn " << txn_id;
       SendSameMachine(forward_txn, SEQUENCER_CHANNEL);
     } else {
       auto partition = RandomPartition(re_);
       auto random_machine_in_home_replica = MakeMachineIdAsString(home_replica, partition);
 
-      VLOG(2) << "Forwarding txn " << txn_id << " to its home region (rep: "
+      VLOG(3) << "Forwarding txn " << txn_id << " to its home region (rep: "
               << home_replica << ", part: " << partition << ")";
 
       Send(
@@ -147,7 +147,7 @@ void Forwarder::Forward(Transaction* txn) {
         config_->GetLocalReplica(),
         config_->GetLeaderPartitionForMultiHomeOrdering());
 
-    VLOG(2) << "Txn " << txn_id << " is a multi-home txn. Sending to the orderer.";
+    VLOG(3) << "Txn " << txn_id << " is a multi-home txn. Sending to the orderer.";
 
     Send(
         forward_txn,

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -199,8 +199,8 @@ void Scheduler::ProcessRemoteReadResult(
     internal::Request&& req) {
   auto txn_id = req.remote_read_result().txn_id();
   auto& holder = all_txns_[txn_id];
-  // A transaction might have a holder but not run yet if there is not
-  // enough worker. In that case, a remote read is still considered an
+  // A transaction might have a holder but not run yet if there are not
+  // enough workers. In that case, a remote read is still considered an
   // early remote read.
   if (holder.txn != nullptr && !holder.worker.empty()) {
     VLOG(2) << "Got remote read result for txn " << txn_id;

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -26,7 +26,7 @@ namespace slog {
 
 struct TransactionHolder {
   Transaction* txn;
-  string worker;
+  string worker = "";
   vector<internal::Request> early_remote_reads;
 };
 

--- a/module/sequencer.cpp
+++ b/module/sequencer.cpp
@@ -113,7 +113,7 @@ void Sequencer::ProcessMultiHomeBatch(Request&& req) {
         lock_only_txn->mutable_write_set()->insert(key_value);
       }
     }
-
+    // TODO: Ignore lock only txns with no key
     PutSingleHomeTransactionIntoBatch(lock_only_txn);
   }
 

--- a/module/server.cpp
+++ b/module/server.cpp
@@ -97,7 +97,10 @@ void Server::HandleAPIRequest(MMessage&& msg) {
             config_->GetLocalMachineIdAsProto());
 
     CHECK(pending_responses_.count(txn_id) == 0) << "Duplicate transaction id: " << txn_id;
+    // The message object is holding the address of the requesting client so we keep it
+    // for later use.
     pending_responses_[txn_id].response = msg;
+    pending_responses_[txn_id].stream_id = request.stream_id();
 
     internal::Request forward_request;
     forward_request.mutable_forward_txn()->set_allocated_txn(txn);

--- a/paxos/quorum_tracker.cpp
+++ b/paxos/quorum_tracker.cpp
@@ -25,6 +25,8 @@ bool QuorumTracker::HandleResponse(
     state_ = QuorumState::COMPLETE;
     return true;
   }
+  // Check whether the current state is already QUORUM_REACHED so that
+  // we only report state change once
   if (sz > num_members_ / 2 && state_ != QuorumState::QUORUM_REACHED) {
     state_ = QuorumState::QUORUM_REACHED;
     return true;


### PR DESCRIPTION
+ Fixed a bug in `SetTransactionType`. This function compared the number of keys in `master_metadata` with the total number of keys of the read and write sets, to determine whether all keys had their metadata filled. This would be wrong when there was a key appearing in both the read and write set. In that case, the total number of keys in the read and write sets would always be larger than the number of metadata, and the txn would never make progress.
+ Fixed a bug in Paxos leader. An iterator was used on the `quorum_trackers_` vector. However, more trackers could be added while iterating, which would invalidate the iterator. 
+ Fixed a bug in the Scheduler. Previously, a remote read was considered "early" if a transaction did not have a holder yet (meaning it had not arrived at the scheduler). This definition is incorrect as a txn could already have a holder and not yet start (making arriving remote read "early) because there was not enough worker. 