### PR TITLE
Mechanism for getting runtime statistics

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -28,7 +28,7 @@ const uint32_t PAXOS_DEFAULT_LEADER_POSITION = 0;
 const size_t LOCK_TABLE_SIZE_LIMIT = 1000000;
 
 /****************************
- *      Statistics Keys
+ *      Statistic Keys
  ****************************/
 
 const char ALL_TXNS[] = "all_txns";

--- a/common/constants.h
+++ b/common/constants.h
@@ -27,4 +27,16 @@ const uint32_t PAXOS_DEFAULT_LEADER_POSITION = 0;
 
 const size_t LOCK_TABLE_SIZE_LIMIT = 1000000;
 
+/****************************
+ *      Statistics Keys
+ ****************************/
+
+const char ALL_TXNS[] = "all_txns";
+const char NUM_ALL_TXNS[] = "num_all_txns";
+const char NUM_READY_WORKERS[] = "num_ready_workers";
+const char NUM_READY_TXNS[] = "num_ready_txns";
+const char NUM_LOCKED_KEYS[] = "num_locked_keys";
+const char NUM_TXNS_WAITING_FOR_LOCK[] = "num_txns_waiting_for_lock";
+const char NUM_LOCKS_WAITED_PER_TXN[] = "num_locks_waited_per_txn";
+
 } // namespace slog

--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -122,7 +122,7 @@ TransactionType SetTransactionType(Transaction& txn) {
     }
   }
 
-  if (!all_master_metadata_received) {
+  if (!all_master_metadata_received) {  
     txn_internal->set_type(TransactionType::UNKNOWN);
     return txn_internal->type();
   }

--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -122,7 +122,7 @@ TransactionType SetTransactionType(Transaction& txn) {
     }
   }
 
-  if (!all_master_metadata_received) {  
+  if (!all_master_metadata_received) {
     txn_internal->set_type(TransactionType::UNKNOWN);
     return txn_internal->type();
   }

--- a/common/service_utils.cpp
+++ b/common/service_utils.cpp
@@ -4,10 +4,10 @@
 
 namespace slog {
 
-void InitializeService(int argc, char* argv[]) {
-  google::InitGoogleLogging(argv[0]);
+void InitializeService(int* argc, char*** argv) {
+  google::InitGoogleLogging((*argv)[0]);
   google::InstallFailureSignalHandler();
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(argc, argv, true /* remove_flags */);
   FLAGS_logtostderr = true;
   FLAGS_colorlogtostderr = true;
   // Verify that the version of the library that we linked against is

--- a/common/service_utils.h
+++ b/common/service_utils.h
@@ -6,6 +6,6 @@
 
 namespace slog {
 
-void InitializeService(int argc, char* argv[]);
+void InitializeService(int* argc, char*** argv);
 
 } // namespace slog

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -233,6 +233,7 @@ void Scheduler::ProcessStatsRequest(const internal::StatsRequest& stats_request)
   stats.SetObject();
   auto& alloc = stats.GetAllocator();
 
+  // Add stats about current transactions in the system
   stats.AddMember(StringRef(NUM_READY_WORKERS), ready_workers_.size(), alloc);
   stats.AddMember(StringRef(NUM_READY_TXNS), ready_txns_.size(), alloc);
   stats.AddMember(StringRef(NUM_ALL_TXNS), all_txns_.size(), alloc);
@@ -244,12 +245,14 @@ void Scheduler::ProcessStatsRequest(const internal::StatsRequest& stats_request)
     stats.AddMember(StringRef(ALL_TXNS), std::move(all_txn_ids), alloc);
   }
 
+  // Add stats from the lock manager
   lock_manager_.GetStats(stats, level);
 
+  // Write JSON object to a buffer and send back to the server
   rapidjson::StringBuffer buf;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
   stats.Accept(writer);
-  
+
   internal::Response res;
   res.mutable_stats()->set_id(stats_request.id());
   res.mutable_stats()->set_stats_json(buf.GetString());

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -58,15 +58,10 @@ private:
   bool HasMessageFromChannel() const;
   bool HasMessageFromWorker() const;
 
-  void ProcessForwardBatch(
-      internal::ForwardBatch* forward_batch,
-      const string& from_machine_id);
-
-  void ProcessLocalQueueOrder(
-      const internal::LocalQueueOrder& order);
-
-  void ProcessRemoteReadResult(
-      internal::Request&& request);
+  void ProcessForwardBatch(internal::ForwardBatch* forward_batch, const string& from_machine_id);
+  void ProcessLocalQueueOrder(const internal::LocalQueueOrder& order);
+  void ProcessRemoteReadResult(internal::Request&& request);
+  void ProcessStatsRequest(const internal::StatsRequest& stats_request);
 
   void MaybeUpdateLocalLog();
   void MaybeProcessNextBatchesFromGlobalLog();

--- a/module/scheduler_components/deterministic_lock_manager.cpp
+++ b/module/scheduler_components/deterministic_lock_manager.cpp
@@ -204,6 +204,7 @@ void DeterministicLockManager::GetStats(rapidjson::Document& stats, uint32_t lev
   stats.AddMember(StringRef(NUM_TXNS_WAITING_FOR_LOCK), num_locks_waited_.size(), alloc);
 
   if (level >= 1) {
+    // Collect number of locks waited per txn
     rapidjson::Value num_locks(rapidjson::kArrayType);
     for (const auto& pair : num_locks_waited_) {
       rapidjson::Value txn_and_locks(rapidjson::kArrayType);

--- a/module/scheduler_components/deterministic_lock_manager.h
+++ b/module/scheduler_components/deterministic_lock_manager.h
@@ -9,6 +9,8 @@
 #include "common/constants.h"
 #include "common/types.h"
 
+#include "third_party/rapidjson/document.h"
+
 using std::list;
 using std::shared_ptr;
 using std::pair;
@@ -91,6 +93,13 @@ public:
    *            all of their locks thanks to this release.
    */
   unordered_set<TxnId> ReleaseLocks(const Transaction& txn);
+
+  /**
+   * Gets current statistics of the lock manager
+   * 
+   * @param stats A JSON object where the statistics are stored into
+   */
+  void GetStats(rapidjson::Document& stats, uint32_t level) const;
 
 private:
   vector<pair<Key, LockMode>> ExtractKeys(const Transaction& txn);

--- a/module/server.cpp
+++ b/module/server.cpp
@@ -90,9 +90,15 @@ void Server::HandleAPIRequest(MMessage&& msg) {
     return;
   }
 
+  // While this is called txn id, we use it for any kind of request
   auto txn_id = NextTxnId();
   CHECK(pending_responses_.count(txn_id) == 0) << "Duplicate transaction id: " << txn_id;
+
+  // The message object holds the address of the client so we keep it here
+  // to response to the client later
   pending_responses_[txn_id].response = msg;
+  // Stream id is used by a client to match up request-response on its side.
+  // The server does not use this and just echos it back to the client.
   pending_responses_[txn_id].stream_id = request.stream_id();
   
   switch (request.type_case()) {

--- a/module/server.h
+++ b/module/server.h
@@ -64,6 +64,7 @@ private:
       internal::Request&& req,
       string&& from_machine_id,
       string&& from_channel);
+  void HandleInternalResponse(internal::Response&& res);
 
   void ProcessLookUpMasterRequest(
       internal::LookupMasterRequest* lookup_master,

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -12,11 +12,22 @@ message Request {
     uint32 stream_id = 1;
     oneof type {
         TransactionRequest txn = 2;
+        StatsRequest stats = 3;
     }
 }
 
 message TransactionRequest {
     Transaction txn = 1;
+}
+
+enum StatsModule {
+    SCHEDULER = 0;
+}
+
+message StatsRequest {
+    StatsModule module = 1;
+    // Level of details, starting from 0
+    uint32 level = 2;
 }
 
 /***********************************************
@@ -27,10 +38,15 @@ message Response {
     uint32 stream_id = 1;
     oneof type {
         TransactionResponse txn = 2;
+        StatsResponse stats = 3;
     }
 }
 
 // For debugging and testing purposes
 message TransactionResponse {
     Transaction txn = 1;
+}
+
+message StatsResponse {
+    bytes stats_json = 1;
 }

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -43,6 +43,7 @@ message Request {
         ProcessTransactionRequest process_txn = 11;
         RemoteReadResult remote_read_result = 12;
         CompletedSubtransaction completed_subtxn = 13;
+        StatsRequest stats = 14;
     }
 }
 
@@ -122,6 +123,11 @@ message CompletedSubtransaction {
     repeated uint32 involved_partitions = 3;
 }
 
+message StatsRequest {
+    uint32 id = 1;
+    uint32 level = 2;
+}
+
 /***********************************************
                     RESPONSES
 ***********************************************/
@@ -135,6 +141,7 @@ message Response {
         PaxosAcceptResponse paxos_accept = 3;
         PaxosCommitResponse paxos_commit = 4;
         ProcessTransactionResponse process_txn = 5;
+        StatsResponse stats = 6;
     }
 }
 
@@ -165,4 +172,9 @@ message PaxosCommitResponse {
 message ProcessTransactionResponse {
     uint32 txn_id = 1;
     repeated uint32 participants = 2;
+}
+
+message StatsResponse {
+    uint32 id = 1;
+    bytes stats_json = 2;
 }

--- a/service/benchmark.cpp
+++ b/service/benchmark.cpp
@@ -56,7 +56,7 @@ void InitializeBenchmark();
 bool StopConditionMet();
 
 int main(int argc, char* argv[]) {
-  InitializeService(argc, argv);
+  InitializeService(&argc, &argv);
   InitializeBenchmark();
 
   LOG(INFO) << "Start sending transactions";

--- a/service/client.cpp
+++ b/service/client.cpp
@@ -1,5 +1,7 @@
 #include <fstream>
-#include <zmq.hpp>
+#include <functional>
+#include <iostream>
+#include <iomanip>
 
 #include "common/service_utils.h"
 #include "common/proto_utils.h"
@@ -11,23 +13,31 @@
 
 DEFINE_string(host, "localhost", "Hostname of the SLOG server to connect to");
 DEFINE_uint32(port, 2023, "Port number of the SLOG server to connect to");
-DEFINE_string(txn_file, "txn.json", "Path to a JSON file containing the transaction");
+DEFINE_uint32(level, 0, "Level of details for the \"stats\" command");
 
 using namespace slog;
 using namespace std;
 
-Transaction* ReadTransactionFromFile(const string& path) {
-  ifstream ifs(path, ios_base::in);
+zmq::context_t context(1);
+zmq::socket_t server_socket(context, ZMQ_DEALER);
+
+/***********************************************
+                Txn Command
+***********************************************/
+
+void ExecuteTxn(const char* txn_file) {
+  // 1. Read txn from file
+  ifstream ifs(txn_file, ios_base::in);
   if (!ifs.is_open()) {
-    LOG(ERROR) << "Could not open file " << path;
-    return nullptr;
+    LOG(ERROR) << "Could not open file " << txn_file;
+    return;
   }
   rapidjson::IStreamWrapper json_stream(ifs);
   rapidjson::Document d;
   d.ParseStream(json_stream);
   if (d.HasParseError()) {
-    LOG(ERROR) << "Could not parse json in " << path;
-    return nullptr;
+    LOG(ERROR) << "Could not parse json in " << txn_file;
+    return;
   }
 
   rapidjson::StringBuffer buffer;
@@ -35,6 +45,7 @@ Transaction* ReadTransactionFromFile(const string& path) {
   d.Accept(writer);
   LOG(INFO) << "Parsed JSON: " << buffer.GetString();
 
+  // 2. Construct a request
   auto read_set_arr = d["read_set"].GetArray();
   unordered_set<string> read_set;
   for (auto& v : read_set_arr) {
@@ -54,48 +65,134 @@ Transaction* ReadTransactionFromFile(const string& path) {
       metadata[mem.name.GetString()] = {mem.value.GetUint(), 0};
     }
   }
+  auto txn = new Transaction(MakeTransaction(
+      read_set,
+      write_set,
+      d["code"].GetString(),
+      metadata));
 
-  return new Transaction(
-      MakeTransaction(
-          read_set,
-          write_set,
-          d["code"].GetString(),
-          metadata));
+  api::Request req;
+  req.mutable_txn()->set_allocated_txn(txn);
+
+  // 3. Send to the server
+  {
+    MMessage msg;
+    msg.Push(req);
+    msg.SendTo(server_socket);
+    LOG(INFO) << "Transaction sent";
+  }
+
+  // 4. Wait and print response
+  {
+    MMessage msg(server_socket);
+    api::Response res;
+    if (!msg.GetProto(res)) {
+      LOG(FATAL) << "Malformed response";
+    } else {
+      const auto& txn = res.txn().txn();
+      cout << txn;
+    }
+  }
+}
+
+/***********************************************
+                Stats Command
+***********************************************/
+
+struct StatsModule {
+  api::StatsModule api_enum;
+  function<void(const rapidjson::Document&, uint32_t level)> print_func;
+};
+
+void PrintSchedulerStats(const rapidjson::Document& stats, uint32_t level) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  stats.Accept(writer);
+
+  cout << "Number of all txns: " << stats[NUM_ALL_TXNS].GetUint() << endl;
+  if (level >= 1) {
+    cout << "List of all txns:\n  ";
+    for (auto& txn_id : stats[ALL_TXNS].GetArray()) {
+      cout << txn_id.GetUint() << " ";
+    }
+    cout << endl;
+  }
+
+  cout << "Number of ready workers: " << stats[NUM_READY_WORKERS].GetUint() << endl;
+  cout << "Number of ready txns: " << stats[NUM_READY_TXNS].GetUint() << endl;
+
+  cout << "Number of locked keys: " << stats[NUM_LOCKED_KEYS].GetUint() << endl;
+  cout << "Number of txns waiting for lock: " << stats[NUM_TXNS_WAITING_FOR_LOCK].GetUint() << endl;
+  if (level >= 1) {
+    cout << "Number of locks waited per txn: " << endl;
+    cout << setw(5) << "Txn" << setw(18) << "# locks waited" << endl;
+    for (auto& pair : stats[NUM_LOCKS_WAITED_PER_TXN].GetArray()) {
+      cout << setw(5) << pair.GetArray()[0].GetUint() 
+           << setw(18) << pair.GetArray()[1].GetUint() << endl;
+    }
+  }
+}
+
+const unordered_map<string, StatsModule> STATS_MODULES = {
+  {"scheduler", {api::StatsModule::SCHEDULER, PrintSchedulerStats}}
+};
+
+void ExecuteStats(const char* module, uint32_t level) {
+  auto& stats_module = STATS_MODULES.at(string(module));
+
+  // 1. Construct a request for stats
+  api::Request req;
+  req.mutable_stats()->set_module(stats_module.api_enum);
+  req.mutable_stats()->set_level(level);
+
+  // 2. Send to the server
+  {
+    MMessage msg;
+    msg.Push(req);
+    msg.SendTo(server_socket);
+  }
+
+  // 3. Wait and print response
+  {
+    MMessage msg(server_socket);
+    api::Response res;
+    if (!msg.GetProto(res)) {
+      LOG(FATAL) << "Malformed response";
+    } else {
+      rapidjson::Document stats;
+      stats.Parse(res.stats().stats_json().c_str());
+      stats_module.print_func(stats, level);
+    }
+  }
 }
 
 int main(int argc, char* argv[]) {
-  InitializeService(argc, argv);
-
-  zmq::context_t context(1);
-  zmq::socket_t socket(context, ZMQ_DEALER);
+  slog::InitializeService(&argc, &argv);
   string endpoint = "tcp://" + FLAGS_host + ":" + to_string(FLAGS_port);
-  socket.connect(endpoint);
-  LOG(INFO) << "Connected to " << endpoint;
+  LOG(INFO) << "Connecting to " << endpoint;
+  server_socket.connect(endpoint);
 
-  auto txn = ReadTransactionFromFile(FLAGS_txn_file);
-  if (txn == nullptr) {
+  if (argc - 1 == 0) {
+    LOG(ERROR) << "Please specify a command";
     return 1;
   }
 
-  {
-    api::Request req;
-    req.mutable_txn()->set_allocated_txn(txn);
-    MMessage msg;
-    msg.Push(req);
-    msg.SendTo(socket);
-  }
-  LOG(INFO) << "Sent a transaction";
-
-  {
-    MMessage msg(socket);
-    api::Response res;
-    if (!msg.GetProto(res)) {
-      LOG(ERROR) << "Malformed response";
-    } else {
-      const auto& txn = res.txn().txn();
-      LOG(INFO) << "Received response. Stream id: " << res.stream_id();
-      cout << txn;
+  if (strcmp(argv[1], "txn") == 0) {
+    if (argc - 1 != 2) {
+      LOG(ERROR) << "Invalid number of arguments for the \"txn\" command:\n"
+                 << "Usage: txn <txn_file>";
+      return 1;
     }
+    ExecuteTxn(argv[2]);
+  } else if (strcmp(argv[1], "stats") == 0) {
+    if (argc - 1 != 2) {
+      LOG(ERROR) << "Invalid number of arguments for the \"stats\" command:\n"
+                 << "Usage: stats <module>";
+      return 1;
+    }
+    ExecuteStats(argv[2], FLAGS_level);
+  } else {
+    LOG(ERROR) << "Invalid command: " << argv[1];
   }
   return 0;
 }

--- a/service/slog.cpp
+++ b/service/slog.cpp
@@ -78,7 +78,7 @@ void LoadData(
 }
 
 int main(int argc, char* argv[]) {
-  slog::InitializeService(argc, argv);
+  slog::InitializeService(&argc, &argv);
   
   auto config = slog::Configuration::FromFile(
       FLAGS_config, 


### PR DESCRIPTION
This would help in debugging. We can now send a request for statistics during runtime 

Example:
```
$ build/client stats scheduler --level 1 -host 172.28.5.1
I0323 02:10:25.001179 11708 client.cpp:172] Connecting to tcp://172.28.5.1:2023
Number of all txns: 493
List of all txns:
  951000 953000 964000 966000 970000 
Number of ready workers: 1
Number of ready txns: 0
Number of locked keys: 3090
Number of txns waiting for lock: 0
Number of locks waited per txn:
  Txn    # locks waited

```