### PR TITLE
Fixed bugs in scheduler and lock manager

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -38,5 +38,10 @@ const char NUM_READY_TXNS[] = "num_ready_txns";
 const char NUM_LOCKED_KEYS[] = "num_locked_keys";
 const char NUM_TXNS_WAITING_FOR_LOCK[] = "num_txns_waiting_for_lock";
 const char NUM_LOCKS_WAITED_PER_TXN[] = "num_locks_waited_per_txn";
+const char LOCK_TABLE[] = "lock_table";
+const char LOCAL_LOG_NUM_BUFFERED_SLOTS[] = "local_log_num_buffered_slots";
+const char LOCAL_LOG_NUM_BUFFERED_BATCHES_PER_QUEUE[] = "local_log_num_buffered_batches_per_queue";
+const char GLOBAL_LOG_NUM_BUFFERED_SLOTS_PER_REGION[] = "global_log_num_buffered_slots_per_region";
+const char GLOBAL_LOG_NUM_BUFFERED_BATCHES_PER_REGION[] = "global_log_num_buffered_batches_per_region";
 
 } // namespace slog

--- a/data_structure/async_log.h
+++ b/data_structure/async_log.h
@@ -51,6 +51,11 @@ public:
     return std::make_pair(position, std::move(result));
   }
 
+  /* For debugging */
+  size_t NumBufferredItems() const {
+    return log_.size();
+  }
+
 private:
   std::unordered_map<uint32_t, T> log_;
   uint32_t next_;

--- a/data_structure/batch_log.h
+++ b/data_structure/batch_log.h
@@ -21,6 +21,16 @@ public:
   bool HasNextBatch() const;
   std::pair<SlotId, BatchPtr> NextBatch();
 
+  /* For debugging */
+  size_t NumBufferedSlots() const {
+    return slots_.NumBufferredItems();
+  }
+
+  /* For debugging */
+  size_t NumBufferedBatches() const {
+    return batches_.size();
+  }
+
 private:
   void UpdateReadyBatches();
 

--- a/module/scheduler_components/batch_interleaver.h
+++ b/module/scheduler_components/batch_interleaver.h
@@ -29,6 +29,20 @@ public:
   bool HasNextBatch() const;
   pair<SlotId, BatchId> NextBatch();
 
+  /* For debugging */
+  size_t NumBufferedSlots() const {
+    return slots_.NumBufferredItems();
+  }
+
+  /* For debugging */
+  unordered_map<uint32_t, size_t> NumBufferedBatchesPerQueue() const {
+    unordered_map<uint32_t, size_t> queue_sizes;
+    for (const auto& pair : batch_queues_) {
+      queue_sizes[pair.first] = pair.second.NumBufferredItems();
+    }
+    return queue_sizes;
+  }
+
 private:
   void UpdateReadyBatches();
 

--- a/module/scheduler_components/deterministic_lock_manager.h
+++ b/module/scheduler_components/deterministic_lock_manager.h
@@ -31,15 +31,24 @@ public:
   bool AcquireReadLock(TxnId txn_id);
   bool AcquireWriteLock(TxnId txn_id);
   unordered_set<TxnId> Release(TxnId txn_id);
-  bool IsQueued(TxnId txn_id);
+  bool Contains(TxnId txn_id);
 
   LockMode mode = LockMode::UNLOCKED;
+
+  /* For debugging */
+  const unordered_set<TxnId>& GetHolders() const {
+    return holders_;
+  }
+
+  /* For debugging */
+  const list<pair<TxnId, LockMode>>& GetWaiters() const {
+    return waiter_queue_;
+  }
 
 private:
   unordered_set<TxnId> holders_;
   unordered_set<TxnId> waiters_;
   list<pair<TxnId, LockMode>> waiter_queue_;
-
 };
 
 /**
@@ -101,6 +110,7 @@ public:
 private:
   unordered_map<Key, LockState> lock_table_;
   unordered_map<TxnId, int32_t> num_locks_waited_;
+  uint32_t num_locked_keys_ = 0;
 };
 
 } // namespace slog

--- a/test/module/scheduler_components/deterministic_lock_manager_test.cpp
+++ b/test/module/scheduler_components/deterministic_lock_manager_test.cpp
@@ -241,3 +241,18 @@ TEST(DeterministicLockManager, GhostTxns) {
   TransactionHolder holder2(configs[0], txn2);
   ASSERT_FALSE(lock_manager.AcquireLocks(holder2));
 }
+
+TEST(DeterministicLockManager, BlockedLockOnlyTxn) {
+  auto configs = MakeTestConfigurations("locking", 1, 1);
+  DeterministicLockManager lock_manager;
+
+  auto txn1 = MakeTransaction({"A"}, {"B"});
+  txn1->mutable_internal()->set_id(100);
+  TransactionHolder holder1(configs[0], txn1);
+  ASSERT_TRUE(lock_manager.AcceptTransactionAndAcquireLocks(holder1));
+
+  auto txn2 = MakeTransaction({}, {"B"});
+  txn2->mutable_internal()->set_id(101);
+  TransactionHolder holder2(configs[0], txn2);
+  ASSERT_FALSE(lock_manager.AcquireLocks(holder2));
+}

--- a/workload/workload_generator.h
+++ b/workload/workload_generator.h
@@ -6,8 +6,8 @@ namespace slog {
 
 const uint32_t MP_NUM_PARTITIONS = 2;
 const uint32_t MH_NUM_HOMES = 2;
-const uint32_t NUM_RECORDS = 2;
-const uint32_t NUM_WRITES = 1;
+const uint32_t NUM_RECORDS = 10;
+const uint32_t NUM_WRITES = 2;
 const uint32_t VALUE_SIZE = 100; // bytes
 
 /**


### PR DESCRIPTION
+ In scheduler, a batch was processed in an incorrect order. It is
now buffered in a stack to get the right order
+ In lock manager, a txn acquring a WRITE_LOCK signed up as a READ_LOCK
in the wait queue. This has been fixed.
+ More stats are collected.