### PR TITLE
Fix deadlock for multi-partition transactions

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -41,8 +41,6 @@ const char PARTIALLY_COMPLETED_TXNS[] = "partially_completed_txns";
 /* Scheduler */
 const char ALL_TXNS[] = "all_txns";
 const char NUM_ALL_TXNS[] = "num_all_txns";
-const char NUM_READY_WORKERS[] = "num_ready_workers";
-const char NUM_READY_TXNS[] = "num_ready_txns";
 const char NUM_LOCKED_KEYS[] = "num_locked_keys";
 const char NUM_TXNS_WAITING_FOR_LOCK[] = "num_txns_waiting_for_lock";
 const char NUM_LOCKS_WAITED_PER_TXN[] = "num_locks_waited_per_txn";

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -220,9 +220,10 @@ void Scheduler::ProcessRemoteReadResult(
     // Save the remote reads that come before the txn
     // is processed by this partition
     //
-    // TODO: If this request is not needed but still arrives AFTER the transaction 
-    // is already commited, it will be stuck in early_remote_reads forever.
-    // Consider garbage collecting them if needed
+    // NOTE: The logic guarantees that it'd never happens but if somehow this
+    // request was not needed but still arrived AFTER the transaction 
+    // was already commited, it would be stuck in early_remote_reads forever.
+    // Consider garbage collecting them if that happens.
     VLOG(2) << "Got early remote read result for txn " << txn_id;
     holder.EarlyRemoteReads().emplace_back(move(req));
   }

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -28,6 +28,7 @@ namespace slog {
 class Scheduler : public Module, ChannelHolder {
 public:
   static const string WORKERS_ENDPOINT;
+  static const uint32_t WORKER_LOAD_THRESHOLD;
 
   Scheduler(
       ConfigurationPtr config,
@@ -48,7 +49,7 @@ private:
   void HandleInternalRequest(
     internal::Request&& req,
     const string& from_machine_id);
-  void HandleResponseFromWorker(internal::Response&& res);
+  void HandleResponseFromWorker(const internal::WorkerResponse& response);
 
   bool HasMessageFromChannel() const;
   bool HasMessageFromWorker() const;

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -63,17 +63,16 @@ private:
   void MaybeProcessNextBatchesFromGlobalLog();
 
   bool AcceptTransaction(Transaction* txn);
-  void EnqueueTransactionForDispatching(TxnId txn_id);
-  void MaybeDispatchNextTransaction();
+  void DispatchTransaction(TxnId txn_id);
 
   void SendToWorker(internal::Request&& req, const string& worker);
 
   ConfigurationPtr config_;
   zmq::socket_t worker_socket_;
   vector<zmq::pollitem_t> poll_items_;
+  vector<string> worker_identities_;
   vector<unique_ptr<ModuleRunner>> workers_;
-  queue<string> ready_workers_;
-  queue<TxnId> ready_txns_;
+  size_t next_worker_;
 
   unordered_map<uint32_t, BatchLog> all_logs_;
   BatchInterleaver local_interleaver_;

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -36,6 +36,7 @@ struct TransactionState {
 class Worker : public Module {
 public:
   Worker(
+      const string& identity,
       ConfigurationPtr config,
       zmq::context_t& context,
       shared_ptr<Storage<Key, Record>> storage);
@@ -50,8 +51,6 @@ private:
   void ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
   
   void ExecuteAndCommitTransaction(TxnId txn_id);
-
-  void SendReadyResponse();
 
   void SendToScheduler(
       const google::protobuf::Message& req_or_res,

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -173,9 +173,6 @@ message WorkerResponse {
     bool has_txn_id = 1;
     uint32 txn_id = 2;
     repeated uint32 participants = 3;
-    // The higher this number is, the more load
-    // the worker is handling
-    uint32 load = 4;
 }
 
 message StatsResponse {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -40,7 +40,7 @@ message Request {
         PaxosAcceptRequest paxos_accept = 8;
         PaxosCommitRequest paxos_commit = 9;
         LocalQueueOrder local_queue_order = 10;
-        ProcessTransactionRequest process_txn = 11;
+        WorkerRequest worker = 11;
         RemoteReadResult remote_read_result = 12;
         CompletedSubtransaction completed_subtxn = 13;
         StatsRequest stats = 14;
@@ -107,7 +107,7 @@ message LocalQueueOrder {
     uint32 slot = 2;
 }
 
-message ProcessTransactionRequest {
+message WorkerRequest {
     uint64 txn_ptr = 1;
 }
 
@@ -140,7 +140,7 @@ message Response {
         LookupMasterResponse lookup_master = 2;
         PaxosAcceptResponse paxos_accept = 3;
         PaxosCommitResponse paxos_commit = 4;
-        ProcessTransactionResponse process_txn = 5;
+        WorkerResponse worker = 5;
         StatsResponse stats = 6;
     }
 }
@@ -169,9 +169,13 @@ message PaxosCommitResponse {
     uint32 slot = 1;
 }
 
-message ProcessTransactionResponse {
-    uint32 txn_id = 1;
-    repeated uint32 participants = 2;
+message WorkerResponse {
+    bool has_txn_id = 1;
+    uint32 txn_id = 2;
+    repeated uint32 participants = 3;
+    // The higher this number is, the more load
+    // the worker is handling
+    uint32 load = 4;
 }
 
 message StatsResponse {

--- a/service/client.cpp
+++ b/service/client.cpp
@@ -208,9 +208,6 @@ void PrintSchedulerStats(const rapidjson::Document& stats, uint32_t level) {
     cout << endl;
   }
 
-  cout << "Ready workers: " << stats[NUM_READY_WORKERS].GetUint() << endl;
-  cout << "Ready txns: " << stats[NUM_READY_TXNS].GetUint() << endl;
-
   cout << "Txns waiting for lock: " << stats[NUM_TXNS_WAITING_FOR_LOCK].GetUint() << endl;
   if (level >= 1) {
     cout << "Locks waited per txn: " << endl;


### PR DESCRIPTION
+ Previously, a worker would block until it receives all needed remote reads. This caused deadlock 
 for example, when there was a single worker per partition and global log orders of two partitions were different. 
+ Scheduler now dispatches txn to workers in a round-robin manner as soon as there is a new txn. Worker sets the awaiting-for-remote-read txn aside and continues with other txns to avoid deadlock.