### PR TITLE
Simple remaster manager

### DIFF
--- a/common/types.h
+++ b/common/types.h
@@ -12,6 +12,7 @@ namespace slog {
 using Key = std::string;
 using Value = std::string;
 using TxnId = uint32_t;
+using TxnReplicaId = uint32_t;
 using BatchId = uint32_t;
 using SlotId = uint32_t;
 

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(scheduler_components
   scheduler_components/batch_interleaver.cpp
   scheduler_components/commands.cpp
   scheduler_components/deterministic_lock_manager.cpp
+  scheduler_components/simple_remaster_manager.cpp
   scheduler_components/worker.cpp)
 target_link_libraries(scheduler_components common)
 

--- a/module/scheduler_components/remaster_manager.h
+++ b/module/scheduler_components/remaster_manager.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <list>
+
+#include "common/types.h"
+
+using std::list;
+
+namespace slog {
+
+enum class VerifyMasterResult {VALID, WAITING, ABORT};
+struct RemasterOccurredResult {
+  list<TxnReplicaId> unblocked;
+  list<TxnReplicaId> should_abort;
+};
+
+/**
+ * The remaster queue manager conducts the check of master metadata.
+ * If a remaster has occured since the transaction was forwarded, it may
+ * need to be restarted. If the transaction arrived before a remaster that
+ * the forwarder included in the metadata, then it will need to wait.
+ */
+class RemasterManager {
+public:
+
+  /**
+   * Checks the counters of the transaction's master metadata.
+   * 
+   * @param txn Transaction to be checked
+   * @return The result of the check.
+   * - If Valid, the transaction can be sent for locks.
+   * - If Waiting, the transaction will be queued until a remaster
+   * txn unblocks it
+   * - If Aborted, the counters were behind and the transaction
+   * needs to be aborted.
+   */
+  virtual VerifyMasterResult VerifyMaster(const TxnReplicaId txn_replica_id) = 0;
+
+  /**
+   * Updates the queue of transactions waiting for remasters,
+   * and returns any newly unblocked transactions.
+   * 
+   * @param key The key that has been remastered
+   * @return A queue of transactions that are now unblocked, in the
+   * order they were submitted
+   */
+  virtual RemasterOccurredResult RemasterOccured(const Key key, const uint32_t remaster_counter) = 0;
+};
+
+} // namespace slog

--- a/module/scheduler_components/simple_remaster_manager.cpp
+++ b/module/scheduler_components/simple_remaster_manager.cpp
@@ -1,0 +1,128 @@
+#include "module/scheduler_components/simple_remaster_manager.h"
+
+#include <glog/logging.h>
+
+namespace slog {
+
+SimpleRemasterManager::SimpleRemasterManager(
+    shared_ptr<Storage<Key, Record>> storage,
+    shared_ptr<TransactionMap> all_txns)
+  : storage_(storage), all_txns_(all_txns) {}
+
+VerifyMasterResult
+SimpleRemasterManager::VerifyMaster(const TxnReplicaId txn_replica_id) {
+  auto& txn_holder = all_txns_->at(txn_replica_id);
+  auto& keys = txn_holder.KeysInPartition();
+  if (keys.empty()) {
+    return VerifyMasterResult::VALID;
+  }
+
+  auto txn = txn_holder.GetTransaction();
+  auto& txn_master_metadata = txn->internal().master_metadata();
+  if (txn_master_metadata.empty()) { // This should only be the case for testing
+    LOG(WARNING) << "Master metadata empty: txn id " << txn->internal().id();
+    return VerifyMasterResult::VALID;
+  }
+
+  // Determine which local log this txn is from. Since only single home or
+  // lock only txns, all keys will have same master
+  uint32_t local_log_machine_id = txn_master_metadata.at(keys.front().first).master();
+
+  // Block this txn behind other txns from same local log
+  // TODO: check the counters now? would abort earlier
+  if (blocked_queue_.count(local_log_machine_id)) {
+    blocked_queue_.at(local_log_machine_id).push_back(txn_replica_id);
+    return VerifyMasterResult::WAITING;
+  }
+
+  // Test counters
+  auto result = CheckCounters(txn_holder);
+  if (result == VerifyMasterResult::WAITING) {
+    blocked_queue_[local_log_machine_id].push_back(txn_replica_id);
+    return VerifyMasterResult::WAITING;
+  } else {
+    return result;
+  }
+}
+
+VerifyMasterResult SimpleRemasterManager::CheckCounters(TransactionHolder& txn_holder) {
+  auto& keys = txn_holder.KeysInPartition();
+  auto& txn_master_metadata = txn_holder.GetTransaction()->internal().master_metadata();
+  for (auto& key_pair : keys) {
+    auto key = key_pair.first;
+
+    // Get txn's counter
+    CHECK(txn_master_metadata.count(key))
+            << "Master metadata for key \"" << key << "\" is missing";
+    auto txn_counter = txn_master_metadata.at(key).counter();
+
+    // Get current counter from storage
+    auto storage_counter = 0; // default to 0 for a new key
+    Record record;
+    bool found = storage_->Read(key, record);
+    if (found) {        
+      storage_counter = record.metadata.counter;
+      CHECK(txn_master_metadata.at(key).master() == record.metadata.master)
+              << "Masters don't match for same key \"" << key << "\"";
+    }
+
+    if (txn_counter < storage_counter) {
+      return VerifyMasterResult::ABORT;
+    } else if (txn_counter > storage_counter) {
+      return VerifyMasterResult::WAITING;
+    }
+  }
+  return VerifyMasterResult::VALID;
+}
+
+RemasterOccurredResult
+SimpleRemasterManager::RemasterOccured(const Key remaster_key, const uint32_t remaster_counter) {
+  RemasterOccurredResult result;
+  // Try to unblock each txn at the head of a queue, if it contains the remastered key.
+  // Note that multiple queues could contain the same key with different counters
+  for (auto& queue_pair : blocked_queue_) {
+    auto txn_replica_id = queue_pair.second.front();
+    auto& txn_keys = all_txns_->at(txn_replica_id).KeysInPartition();
+    for (auto& key_pair : txn_keys) {
+      auto txn_key = key_pair.first;
+      if (txn_key == remaster_key) {
+        TryToUnblock(queue_pair.first, result);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+void SimpleRemasterManager::TryToUnblock(
+    const uint32_t local_log_machine_id,
+    RemasterOccurredResult& result) {
+  if (blocked_queue_.count(local_log_machine_id) == 0) {
+    return;
+  }
+
+  auto txn_replica_id = blocked_queue_.at(local_log_machine_id).front();
+  auto& txn_holder = all_txns_->at(txn_replica_id);
+  auto& keys = txn_holder.KeysInPartition();
+
+  auto counter_result = CheckCounters(txn_holder);
+  if (counter_result == VerifyMasterResult::WAITING) {
+    return;
+  } else if (counter_result == VerifyMasterResult::VALID) {
+    result.unblocked.push_back(txn_replica_id);
+  } else if (counter_result == VerifyMasterResult::ABORT) {
+    result.should_abort.push_back(txn_replica_id);
+  }
+
+  // Head of queue has changed
+  blocked_queue_.at(local_log_machine_id).pop_front();
+  if (blocked_queue_.at(local_log_machine_id).empty()) {
+    // garbage collect
+    blocked_queue_.erase(local_log_machine_id);
+  } else {
+    // recurse on new front of queue
+    TryToUnblock(local_log_machine_id, result);
+  }
+}
+
+} // namespace slog

--- a/module/scheduler_components/simple_remaster_manager.cpp
+++ b/module/scheduler_components/simple_remaster_manager.cpp
@@ -26,7 +26,7 @@ SimpleRemasterManager::VerifyMaster(const TxnReplicaId txn_replica_id) {
 
   // Determine which local log this txn is from. Since only single home or
   // lock only txns, all keys will have same master
-  uint32_t local_log_machine_id = txn_master_metadata.at(keys.front().first).master();
+  auto local_log_machine_id = txn_master_metadata.begin()->second.master();
 
   // Block this txn behind other txns from same local log
   // TODO: check the counters now? would abort earlier

--- a/module/scheduler_components/simple_remaster_manager.cpp
+++ b/module/scheduler_components/simple_remaster_manager.cpp
@@ -86,6 +86,7 @@ SimpleRemasterManager::RemasterOccured(const Key remaster_key, const uint32_t re
     for (auto& key_pair : txn_keys) {
       auto txn_key = key_pair.first;
       if (txn_key == remaster_key) {
+        // TODO: check here if counters match, saves an iteration through all keys
         TryToUnblock(queue_pair.first, result);
         break;
       }

--- a/module/scheduler_components/simple_remaster_manager.h
+++ b/module/scheduler_components/simple_remaster_manager.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "module/scheduler_components/remaster_manager.h"
+
+#include "common/transaction_utils.h"
+
+#include "storage/storage.h"
+
+using std::shared_ptr;
+using std::unordered_map;
+
+
+namespace slog {
+
+using TransactionMap = unordered_map<TxnReplicaId, TransactionHolder>;
+
+class SimpleRemasterManager :
+    public RemasterManager {
+public:
+  SimpleRemasterManager(
+    shared_ptr<Storage<Key, Record>> storage,
+    shared_ptr<TransactionMap> all_txns);
+
+  virtual VerifyMasterResult VerifyMaster(const TxnReplicaId txn_replica_id);
+  virtual RemasterOccurredResult RemasterOccured(const Key key, const uint32_t remaster_counter);
+
+private:
+  VerifyMasterResult CheckCounters(TransactionHolder& txn_holder);
+  void TryToUnblock(const uint32_t local_log_machine_id, RemasterOccurredResult& result);
+
+  shared_ptr<Storage<Key, Record>> storage_;
+  unordered_map<uint32_t, list<TxnReplicaId>> blocked_queue_;
+  shared_ptr<TransactionMap> all_txns_;
+
+};
+
+} // namespace slog

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -22,11 +22,14 @@ message MasterMetadata {
 }
 
 message TransactionInternal {
+    // unique transaction id, multi-home and lock only
+    // txns share this id
     uint32 id = 1;
     map<string, MasterMetadata> master_metadata = 2;
     TransactionType type = 3;
     internal.MachineId coordinating_server = 4;
-    uint32 replica_id = 5;
+    // unique id for lock only txns
+    uint32 txn_replica_id = 5;
 }
 
 message Transaction {

--- a/proto/transaction.proto
+++ b/proto/transaction.proto
@@ -26,6 +26,7 @@ message TransactionInternal {
     map<string, MasterMetadata> master_metadata = 2;
     TransactionType type = 3;
     internal.MachineId coordinating_server = 4;
+    uint32 replica_id = 5;
 }
 
 message Transaction {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,8 @@ set(ALL_TESTS
   proto_utils_test
   scheduler_test
   server_test
-  sequencer_test)
+  sequencer_test
+  simple_remaster_manager_test)
 
 add_executable(batch_log_test data_structure/batch_log_test.cpp)
 target_link_libraries(batch_log_test batch_log proto)
@@ -68,6 +69,10 @@ target_link_libraries(server_test test_utils)
 
 add_executable(sequencer_test module/sequencer_test.cpp)
 target_link_libraries(sequencer_test test_utils)
+
+add_executable(simple_remaster_manager_test 
+   module/scheduler_components/simple_remaster_manager_test.cpp)
+ target_link_libraries(simple_remaster_manager_test test_utils)
 
 foreach(TEST ${ALL_TESTS})
   target_link_libraries(${TEST} ${EXTERNAL_LIBS} GTest::GTest GTest::Main)

--- a/test/module/scheduler_components/simple_remaster_manager_test.cpp
+++ b/test/module/scheduler_components/simple_remaster_manager_test.cpp
@@ -41,7 +41,8 @@ protected:
 
 TEST_F(SimpleRemasterManagerTest, ValidateMetadata) {
   storage->Write("A", Record("value", 0, 1));
-  auto& txn1 = MakeHolder(MakeTransaction({"A", "B"}, {}, "some code", {{"B", {1, 1}}}), 100);
+  storage->Write("B", Record("value", 0, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A", "B"}, {}, "some code", {{"B", {0, 1}}}), 100);
   auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {1, 1}}}), 101);
   ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), "metadata for key .* is missing");
   ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), "Masters don't match");

--- a/test/module/scheduler_components/simple_remaster_manager_test.cpp
+++ b/test/module/scheduler_components/simple_remaster_manager_test.cpp
@@ -27,7 +27,7 @@ protected:
 
     auto txn_replica_id = txn_id;
     txn->mutable_internal()->set_id(txn_id);
-    txn->mutable_internal()->set_replica_id(txn_replica_id);
+    txn->mutable_internal()->set_txn_replica_id(txn_replica_id);
     CHECK(all_txns->count(txn->internal().id()) == 0) << "Need to set txns to unique id's";
     auto& holder = (*all_txns)[txn_replica_id];
     holder.SetTransaction(configs[0], txn);
@@ -35,7 +35,7 @@ protected:
   }
 
   TxnReplicaId GetTxnReplicaId(TransactionHolder& holder) {
-    return holder.GetTransaction()->internal().replica_id();
+    return holder.GetTransaction()->internal().txn_replica_id();
   }
 };
 

--- a/test/module/scheduler_components/simple_remaster_manager_test.cpp
+++ b/test/module/scheduler_components/simple_remaster_manager_test.cpp
@@ -1,0 +1,97 @@
+#include <gmock/gmock.h>
+
+#include "common/test_utils.h"
+#include "common/proto_utils.h"
+
+#include "module/scheduler_components/simple_remaster_manager.h"
+
+using namespace std;
+using namespace slog;
+using ::testing::ElementsAre;
+
+class SimpleRemasterManagerTest : public ::testing::Test {
+protected:
+  void SetUp() {
+    configs = MakeTestConfigurations("remaster", 2, 1);
+    storage = make_shared<slog::MemOnlyStorage<Key, Record, Metadata>>();
+    all_txns = make_shared<TransactionMap>();
+    remaster_manager = make_unique<SimpleRemasterManager>(storage, all_txns);
+  }
+
+  ConfigVec configs;
+  shared_ptr<Storage<Key, Record>> storage;
+  shared_ptr<TransactionMap> all_txns;
+  unique_ptr<RemasterManager> remaster_manager;
+
+  TransactionHolder& MakeHolder(Transaction* txn, TxnId txn_id) {
+
+    auto txn_replica_id = txn_id;
+    txn->mutable_internal()->set_id(txn_id);
+    txn->mutable_internal()->set_replica_id(txn_replica_id);
+    CHECK(all_txns->count(txn->internal().id()) == 0) << "Need to set txns to unique id's";
+    auto& holder = (*all_txns)[txn_replica_id];
+    holder.SetTransaction(configs[0], txn);
+    return holder;
+  }
+
+  TxnReplicaId GetTxnReplicaId(TransactionHolder& holder) {
+    return holder.GetTransaction()->internal().replica_id();
+  }
+};
+
+TEST_F(SimpleRemasterManagerTest, ValidateMetadata) {
+  storage->Write("A", Record("value", 0, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A", "B"}, {}, "some code", {{"B", {1, 1}}}), 100);
+  auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {1, 1}}}), 101);
+  ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), "metadata for key .* is missing");
+  ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), "Masters don't match");
+}
+
+TEST_F(SimpleRemasterManagerTest, CheckCounters) {
+  storage->Write("A", Record("value", 0, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 1}}}), 100);
+  auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 0}}}), 101);
+  auto& txn3 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 2}}}), 102);
+
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), VerifyMasterResult::VALID);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), VerifyMasterResult::ABORT);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn3)), VerifyMasterResult::WAITING);
+}
+
+TEST_F(SimpleRemasterManagerTest, CheckMultipleCounters) {
+  storage->Write("A", Record("value", 0, 1));
+  storage->Write("B", Record("value", 0, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A"}, {"B"}, "some code", {{"A", {0, 1}}, {"B", {0, 1}}}), 100);
+  auto& txn2 = MakeHolder(MakeTransaction({"A", "B"}, {}, "some code", {{"A", {0, 0}}, {"B", {0, 1}}}), 101);
+  auto& txn3 = MakeHolder(MakeTransaction({}, {"A", "B"}, "some code", {{"A", {0, 1}}, {"B", {0, 2}}}), 102);
+
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), VerifyMasterResult::VALID);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), VerifyMasterResult::ABORT);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn3)), VerifyMasterResult::WAITING);
+}
+
+TEST_F(SimpleRemasterManagerTest, BlockLocalLog) {
+  storage->Write("A", Record("value", 0, 1));
+  storage->Write("B", Record("value", 1, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 2}}}), 100);
+  auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 1}}}), 101);
+  auto& txn3 = MakeHolder(MakeTransaction({"B"}, {}, "some code", {{"B", {1, 1}}}), 102);
+
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), VerifyMasterResult::WAITING);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), VerifyMasterResult::WAITING);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn3)), VerifyMasterResult::VALID);
+}
+
+TEST_F(SimpleRemasterManagerTest, RemasterReleases) {
+  storage->Write("A", Record("value", 0, 1));
+  auto& txn1 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 2}}}), 100);
+  auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {0, 1}}}), 101);
+
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), VerifyMasterResult::WAITING);
+  ASSERT_EQ(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), VerifyMasterResult::WAITING);
+
+  storage->Write("A", Record("value", 0, 2));
+  auto result = remaster_manager->RemasterOccured("A", 2);
+  ASSERT_THAT(result.unblocked, ElementsAre(100));
+  ASSERT_THAT(result.should_abort, ElementsAre(101));
+}

--- a/test/module/scheduler_components/simple_remaster_manager_test.cpp
+++ b/test/module/scheduler_components/simple_remaster_manager_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SimpleRemasterManagerTest, ValidateMetadata) {
   storage->Write("B", Record("value", 0, 1));
   auto& txn1 = MakeHolder(MakeTransaction({"A", "B"}, {}, "some code", {{"B", {0, 1}}}), 100);
   auto& txn2 = MakeHolder(MakeTransaction({"A"}, {}, "some code", {{"A", {1, 1}}}), 101);
-  ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)), "metadata for key .* is missing");
+  ASSERT_ANY_THROW(remaster_manager->VerifyMaster(GetTxnReplicaId(txn1)));
   ASSERT_DEATH(remaster_manager->VerifyMaster(GetTxnReplicaId(txn2)), "Masters don't match");
 }
 


### PR DESCRIPTION
Transactions are kept in the exact order as their local logs: if a transaction from region 1 is blocked in the queue, all following transactions from region 1 will be blocked behind it.

This implementation trades performance for being easy to verify.