### PR TITLE
Fixed timing issue in Sequencer and MultiHomeOrderer

### DIFF
--- a/common/test_utils.h
+++ b/common/test_utils.h
@@ -54,6 +54,7 @@ private:
   shared_ptr<zmq::context_t> context_;
   shared_ptr<MemOnlyStorage<Key, Record, Metadata>> storage_;
   Broker broker_;
+  ModuleRunnerPtr ticker_;
   ModuleRunnerPtr server_;
   ModuleRunnerPtr forwarder_;
   ModuleRunnerPtr sequencer_;

--- a/connection/channel.cpp
+++ b/connection/channel.cpp
@@ -65,4 +65,8 @@ std::unique_ptr<Channel> Channel::GetListener() {
   return std::unique_ptr<Channel>(new Channel(context_, name_, true /* is_listener */));
 }
 
+const std::shared_ptr<zmq::context_t>& Channel::GetContext() const {
+  return context_;
+}
+
 } // namespace slog;

--- a/connection/channel.h
+++ b/connection/channel.h
@@ -44,6 +44,11 @@ public:
    */
   std::unique_ptr<Channel> GetListener();
 
+  /**
+   * Returns the zmq context
+   */
+  const std::shared_ptr<zmq::context_t>& GetContext() const;
+
 private:
   Channel(
       std::shared_ptr<zmq::context_t> context,

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -27,7 +27,8 @@ target_link_libraries(module
   batch_log
   base_module
   paxos
-  scheduler_components)
+  scheduler_components
+  ticker)
 
 add_library(ticker ticker.cpp)
 target_link_libraries(ticker base_module common)

--- a/module/base/basic_module.cpp
+++ b/module/base/basic_module.cpp
@@ -64,7 +64,9 @@ void BasicModule::Loop() {
     }
   }
 
-  // Message from one of the custom sockets
+  // Message from one of the custom sockets. These sockets
+  // are indexed from 1 in poll_items_. The first poll item
+  // belongs to the channel socket.
   for (size_t i = 1; i < poll_items_.size(); i++) {
     if (poll_items_[i].revents & ZMQ_POLLIN) {
       MMessage msg(custom_sockets_[i - 1]);

--- a/module/base/basic_module.h
+++ b/module/base/basic_module.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "common/constants.h"
 #include "common/types.h"
 #include "module/base/module.h"
@@ -16,30 +18,30 @@ class BasicModule : public Module, public ChannelHolder {
 public:
   BasicModule(
       const std::string& name,
-      unique_ptr<Channel>&& listener,
-      long wake_up_every_ms = -1L);
+      std::unique_ptr<Channel>&& listener);
 
 protected:
+  virtual std::vector<zmq::socket_t> InitializeCustomSockets();
+
   virtual void HandleInternalRequest(
       internal::Request&& req,
-      string&& from_machine_id) = 0;
+      std::string&& from_machine_id) = 0;
 
   virtual void HandleInternalResponse(
       internal::Response&& /* res */,
-      string&& /* from_machine_id */) {};
+      std::string&& /* from_machine_id */) {};
 
-  virtual void HandlePeriodicWakeUp() {};
+  virtual void HandleCustomSocketMessage(
+      const MMessage& /* msg */,
+      size_t /* socket_index */) {};
 
 private:
+  void SetUp() final;
   void Loop() final;
 
-  bool NeedWakeUp() const;
-
   std::string name_;
-  zmq::pollitem_t poll_item_;
-  long wake_up_every_ms_;
-  long poll_timeout_ms_;
-  TimePoint wake_up_deadline_;
+  std::vector<zmq::pollitem_t> poll_items_;
+  std::vector<zmq::socket_t> custom_sockets_;
 };
 
 } // namespace slog

--- a/module/base/module.cpp
+++ b/module/base/module.cpp
@@ -3,6 +3,9 @@
 #include "common/constants.h"
 #include "common/mmessage.h"
 
+using std::shared_ptr;
+using std::unique_ptr;
+
 namespace slog {
 
 ModuleRunner::ModuleRunner(const shared_ptr<Module>& module) 
@@ -88,5 +91,8 @@ zmq::pollitem_t ChannelHolder::GetChannelPollItem() const {
   return channel_->GetPollItem();
 }
 
+const shared_ptr<zmq::context_t>& ChannelHolder::GetContext() const {
+  return channel_->GetContext();
+}
 
 } // namespace slog

--- a/module/base/module.h
+++ b/module/base/module.h
@@ -6,10 +6,6 @@
 
 #include "connection/channel.h"
 
-using std::shared_ptr;
-using std::unique_ptr;
-using std::string;
-
 namespace slog {
 
 /**
@@ -47,7 +43,7 @@ public:
  */
 class ModuleRunner {
 public:
-  ModuleRunner(const shared_ptr<Module>& module);
+  ModuleRunner(const std::shared_ptr<Module>& module);
   ~ModuleRunner();
 
   void Start();
@@ -56,7 +52,7 @@ public:
 private:
   void Run();
 
-  shared_ptr<Module> module_;
+  std::shared_ptr<Module> module_;
   std::thread thread_;
   std::atomic<bool> running_;
 };
@@ -65,7 +61,7 @@ private:
  * Helper function for creating a ModuleRunner.
  */
 template<typename T, typename... Args>
-inline unique_ptr<ModuleRunner>
+inline std::unique_ptr<ModuleRunner>
 MakeRunnerFor(Args&&... args)
 {
   return std::make_unique<ModuleRunner>(
@@ -77,7 +73,7 @@ MakeRunnerFor(Args&&... args)
  */
 class ChannelHolder {
 public:
-  ChannelHolder(unique_ptr<Channel>&& channel_);
+  ChannelHolder(std::unique_ptr<Channel>&& channel_);
 
   /**
    * Send a request or response to a given channel of a given machine
@@ -89,8 +85,8 @@ public:
    */
   void Send(
       const google::protobuf::Message& request_or_response,
-      const string& to_machine_id,
-      const string& to_channel,
+      const std::string& to_machine_id,
+      const std::string& to_channel,
       bool has_more = false);
 
   /**
@@ -125,12 +121,14 @@ public:
    */
   void Send(MMessage&& message, bool has_more = false);
 
-  zmq::pollitem_t GetChannelPollItem() const;
-
   void ReceiveFromChannel(MMessage& message);
 
+  zmq::pollitem_t GetChannelPollItem() const;
+
+  const std::shared_ptr<zmq::context_t>& GetContext() const;
+
 private:
-  unique_ptr<Channel> channel_;
+  std::unique_ptr<Channel> channel_;
 };
 
 } // namespace slog

--- a/module/multi_home_orderer.cpp
+++ b/module/multi_home_orderer.cpp
@@ -22,10 +22,7 @@ MultiHomeOrderer::MultiHomeOrderer(ConfigurationPtr config, Broker& broker)
 
 std::vector<zmq::socket_t> MultiHomeOrderer::InitializeCustomSockets() {
   vector<zmq::socket_t> ticker_socket;
-  ticker_socket.emplace_back(*GetContext(), ZMQ_SUB);
-  ticker_socket.front().connect(Ticker::ENDPOINT);
-  // Subscribe to any message
-  ticker_socket.front().setsockopt(ZMQ_SUBSCRIBE, "", 0);
+  ticker_socket.push_back(Ticker::Subscribe(*GetContext()));
   return ticker_socket;
 }
 

--- a/module/multi_home_orderer.h
+++ b/module/multi_home_orderer.h
@@ -27,11 +27,15 @@ public:
   MultiHomeOrderer(ConfigurationPtr config, Broker& broker);
 
 protected:
+  std::vector<zmq::socket_t> InitializeCustomSockets() final;
+
   void HandleInternalRequest(
       internal::Request&& req,
       string&& from_machine_id) final;
 
-  void HandlePeriodicWakeUp() final;
+  void HandleCustomSocketMessage(
+      const MMessage& msg,
+      size_t socket_index) final;
 
 private:
   void NewBatch();

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -27,8 +27,8 @@ Scheduler::Scheduler(
     // range, num_replicas can be used as the marker for MULTI-HOME txn log
     kMultiHomeTxnLogMarker(config->GetNumReplicas()),
     config_(config),
-    remaster_manager_(storage),
-    worker_socket_(context, ZMQ_ROUTER) {
+    worker_socket_(context, ZMQ_ROUTER),
+    remaster_manager_(storage) {
   worker_socket_.setsockopt(ZMQ_LINGER, 0);
   worker_socket_.setsockopt(ZMQ_RCVHWM, 0);
   worker_socket_.setsockopt(ZMQ_SNDHWM, 0);

--- a/module/sequencer.cpp
+++ b/module/sequencer.cpp
@@ -22,10 +22,7 @@ Sequencer::Sequencer(ConfigurationPtr config, Broker& broker)
 
 vector<zmq::socket_t> Sequencer::InitializeCustomSockets() {
   vector<zmq::socket_t> ticker_socket;
-  ticker_socket.emplace_back(*GetContext(), ZMQ_SUB);
-  ticker_socket.front().connect(Ticker::ENDPOINT);
-  // Subscribe to any message
-  ticker_socket.front().setsockopt(ZMQ_SUBSCRIBE, "", 0);
+  ticker_socket.push_back(Ticker::Subscribe(*GetContext()));
   return ticker_socket;
 }
 

--- a/module/sequencer.h
+++ b/module/sequencer.h
@@ -30,11 +30,15 @@ public:
   Sequencer(ConfigurationPtr config, Broker& broker);
 
 protected:
+  std::vector<zmq::socket_t> InitializeCustomSockets() final;
+
   void HandleInternalRequest(
       internal::Request&& req,
       string&& from_machine_id) final;
 
-  void HandlePeriodicWakeUp() final;
+  void HandleCustomSocketMessage(
+      const MMessage& msg,
+      size_t socket_index) final;
 
 private:
   void NewBatch();

--- a/module/ticker.cpp
+++ b/module/ticker.cpp
@@ -4,11 +4,16 @@ namespace slog {
 
 const string Ticker::ENDPOINT("inproc://ticker");
 
-Ticker::Ticker(zmq::context_t& context, uint32_t ticks_per_sec)
-    : socket_(context, ZMQ_PUB),
-      ticks_per_sec_(ticks_per_sec) {
+Ticker::Ticker(zmq::context_t& context, std::chrono::milliseconds tick_period_ms)
+    : socket_(context, ZMQ_PUB) {
   socket_.setsockopt(ZMQ_LINGER, 0);
-  sleep_us_ = std::chrono::microseconds(1000 * 1000 / ticks_per_sec_);
+  sleep_us_ = std::chrono::duration_cast<milliseconds>(tick_period_ms);
+}
+
+Ticker::Ticker(zmq::context_t& context, uint32_t ticks_per_sec)
+    : socket_(context, ZMQ_PUB) {
+  socket_.setsockopt(ZMQ_LINGER, 0);
+  sleep_us_ = std::chrono::microseconds(1000 * 1000 / ticks_per_sec);
 }
 
 void Ticker::SetUp() {

--- a/module/ticker.cpp
+++ b/module/ticker.cpp
@@ -4,6 +4,14 @@ namespace slog {
 
 const string Ticker::ENDPOINT("inproc://ticker");
 
+zmq::socket_t Ticker::Subscribe(zmq::context_t& context) {
+  zmq::socket_t socket(context, ZMQ_SUB);
+  socket.connect(Ticker::ENDPOINT);
+  // Subscribe to any message
+  socket.setsockopt(ZMQ_SUBSCRIBE, "", 0);
+  return socket;
+}
+
 Ticker::Ticker(zmq::context_t& context, std::chrono::milliseconds tick_period_ms)
     : socket_(context, ZMQ_PUB) {
   socket_.setsockopt(ZMQ_LINGER, 0);

--- a/module/ticker.h
+++ b/module/ticker.h
@@ -11,6 +11,7 @@ class Ticker : public Module {
 public:
   const static string ENDPOINT;
 
+  Ticker(zmq::context_t& context, std::chrono::milliseconds tick_period_ms);
   Ticker(zmq::context_t& context, uint32_t ticks_per_sec);
 
   void SetUp() final;
@@ -18,7 +19,6 @@ public:
 
 private:
   zmq::socket_t socket_;
-  uint32_t ticks_per_sec_;
   Duration sleep_us_;
 };
 

--- a/module/ticker.h
+++ b/module/ticker.h
@@ -10,6 +10,7 @@ namespace slog {
 class Ticker : public Module {
 public:
   const static string ENDPOINT;
+  static zmq::socket_t Subscribe(zmq::context_t& context);
 
   Ticker(zmq::context_t& context, std::chrono::milliseconds tick_period_ms);
   Ticker(zmq::context_t& context, uint32_t ticks_per_sec);

--- a/service/benchmark.cpp
+++ b/service/benchmark.cpp
@@ -154,9 +154,8 @@ void InitializeBenchmark() {
   // Create a ticker and subscribe to it
   ticker = MakeRunnerFor<Ticker>(context, FLAGS_rate);
   ticker->StartInNewThread();
-  ticker_socket = make_unique<zmq::socket_t>(context, ZMQ_SUB);
-  ticker_socket->connect(Ticker::ENDPOINT);
-  ticker_socket->setsockopt(ZMQ_SUBSCRIBE, "", 0);
+  ticker_socket = make_unique<zmq::socket_t>(
+      Ticker::Subscribe(context));
   // This has to be pushed to poll_items before the server sockets
   poll_items.push_back({
       static_cast<void*>(*ticker_socket),
@@ -270,6 +269,7 @@ void SendNextTransaction() {
   if (FLAGS_dry_run) {
     return;
   }
+
   api::Request req;
   req.mutable_txn()->set_allocated_txn(txn);
   req.set_stream_id(stats.txn_counter);

--- a/service/slog.cpp
+++ b/service/slog.cpp
@@ -12,6 +12,7 @@
 #include "module/scheduler.h"
 #include "module/server.h"
 #include "module/sequencer.h"
+#include "module/ticker.h"
 #include "proto/internal.pb.h"
 #include "proto/offline_data.pb.h"
 #include "storage/mem_only_storage.h"
@@ -115,6 +116,8 @@ int main(int argc, char* argv[]) {
   auto server = MakeRunnerFor<slog::Server>(config, *context, broker, storage);
 
   vector<unique_ptr<slog::ModuleRunner>> modules;
+  modules.push_back(
+      MakeRunnerFor<slog::Ticker>(*context, milliseconds(config->GetBatchDuration())));
   modules.push_back(
       MakeRunnerFor<slog::LocalPaxos>(config, broker));
   modules.push_back(


### PR DESCRIPTION
The implementation for Sequencer and MultiHomeOrderer to wake up periodically was flawed. The timeout of `zmq::poll` was computed dynamically and it was hard to maintain the precision of this computation under high load, leading to batches that might wait for 100s of milliseconds before being sent.
This PR fixes this by subscribing those modules to the Ticker, which sends out a message every set amount of time. 