### PR TITLE
Final remaster counter check in worker

### DIFF
--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -581,8 +581,8 @@ void Scheduler::DispatchTransaction(TxnId txn_id) {
   // Prepare a request with the txn to be sent to the worker
   Request req;
   auto worker_request = req.mutable_worker();
-  worker_request->set_txn_ptr(
-      reinterpret_cast<uint64_t>(txn));
+  worker_request->set_txn_holder_ptr(
+      reinterpret_cast<uint64_t>(&holder));
 
   RecordTxnEvent(
       config_,

--- a/module/scheduler_components/simple_remaster_manager.h
+++ b/module/scheduler_components/simple_remaster_manager.h
@@ -4,9 +4,6 @@
 
 #include "module/scheduler_components/remaster_manager.h"
 
-#include "storage/storage.h"
-
-using std::shared_ptr;
 using std::unordered_map;
 
 
@@ -27,11 +24,6 @@ public:
   virtual RemasterOccurredResult RemasterOccured(const Key key, const uint32_t remaster_counter);
 
 private:
-  /**
-   * Compare transaction metadata to stored metadata
-   */
-  VerifyMasterResult CheckCounters(const TransactionHolder* txn_holder);
-
   /**
    * Test if the head of this queue can be unblocked
    */

--- a/module/scheduler_components/worker.cpp
+++ b/module/scheduler_components/worker.cpp
@@ -180,7 +180,7 @@ void Worker::ProcessRemoteReadResult(const internal::RemoteReadResult& read_resu
   CHECK(txn_states_.count(txn_id) > 0)
       << "Transaction " << txn_id << " does not exist for remote read result";
 
-  auto txn = txn_states_[txn_id].txn;
+  auto txn = txn_states_[txn_id].txn_holder->GetTransaction();
   auto& rpp = txn_states_[txn_id].remote_passive_partitions;
 
   if (rpp.count(read_result.partition()) > 0) {
@@ -201,7 +201,7 @@ void Worker::ProcessRemoteReadResult(const internal::RemoteReadResult& read_resu
 
 void Worker::ExecuteAndCommitTransaction(TxnId txn_id) {
   const auto& state = txn_states_[txn_id];
-  auto txn = state.txn;
+  auto txn = state.txn_holder->GetTransaction();
   auto holder = state.txn_holder;
   switch(RemasterManager::CheckCounters(holder, storage_)) {
     case VerifyMasterResult::VALID: {
@@ -246,7 +246,7 @@ void Worker::ExecuteAndCommitTransaction(TxnId txn_id) {
 
 void Worker::ExecuteTransactionHelper(TxnId txn_id) {
   const auto& state = txn_states_[txn_id];
-  auto txn = state.txn;
+  auto txn = state.txn_holder->GetTransaction();
   if (txn->procedure_case() == Transaction::ProcedureCase::kCode) {
     // Execute the transaction code
     commands_->Execute(*txn);

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -22,11 +22,8 @@ namespace slog {
 
 struct TransactionState {
   TransactionState() = default;
-  TransactionState(TransactionHolder* txn_holder) :
-      txn(txn_holder->GetTransaction()),
-      txn_holder(txn_holder) {}
+  TransactionState(TransactionHolder* txn_holder) : txn_holder(txn_holder) {}
 
-  Transaction* txn;
   TransactionHolder* txn_holder;
   bool has_local_reads;
   bool has_local_writes;

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -7,6 +7,7 @@
 
 #include "common/configuration.h"
 #include "common/types.h"
+#include "common/transaction_holder.h"
 #include "module/base/module.h"
 #include "module/scheduler_components/commands.h"
 #include "proto/transaction.pb.h"
@@ -21,9 +22,12 @@ namespace slog {
 
 struct TransactionState {
   TransactionState() = default;
-  TransactionState(Transaction* txn) : txn(txn) {}
+  TransactionState(TransactionHolder* txn_holder) :
+      txn(txn_holder->GetTransaction()),
+      txn_holder(txn_holder) {}
 
   Transaction* txn;
+  TransactionHolder* txn_holder;
   bool has_local_reads;
   bool has_local_writes;
   // This set is reduced until we receive remote
@@ -45,12 +49,13 @@ public:
 
 private:
   void ProcessWorkerRequest(const internal::WorkerRequest& req);
-  TransactionState& InitializeTransactionState(Transaction* txn);
+  TransactionState& InitializeTransactionState(TransactionHolder* txn);
   void PopulateDataFromLocalStorage(Transaction* txn);
 
   void ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
   
   void ExecuteAndCommitTransaction(TxnId txn_id);
+  void ExecuteTransactionHelper(TxnId txn_id);
 
   void SendToScheduler(
       const google::protobuf::Message& req_or_res,

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -113,7 +113,7 @@ message LocalQueueOrder {
 }
 
 message WorkerRequest {
-    uint64 txn_ptr = 1;
+    uint64 txn_holder_ptr = 1;
 }
 
 message RemoteReadResult {

--- a/test/e2e/e2e_test.cpp
+++ b/test/e2e/e2e_test.cpp
@@ -122,6 +122,36 @@ TEST_F(E2ETest, MultiHomeMutliPartitionTxn) {
   }
 }
 
+TEST_F(E2ETest, RemasterTxn) {
+  for (size_t i = 0; i < NUM_MACHINES; i++) {
+    // auto txn = MakeTransaction({"A", "X"} /* read_set */, {}  /* write_set */);
+
+    auto remaster_txn = MakeTransaction(
+        {}, /* read_set */
+        {"A"},  /* write_set */
+        "", /* code */
+        {}, /* master metadata */
+        MakeMachineId("0:0") /* coordinating server */,
+        1 /* new master */);
+
+    test_slogs[i]->SendTxn(remaster_txn);
+    auto remaster_txn_resp = test_slogs[i]->RecvTxnResult();
+    ASSERT_EQ(TransactionStatus::COMMITTED, remaster_txn_resp.status());
+    ASSERT_EQ(TransactionType::SINGLE_HOME, remaster_txn_resp.internal().type());
+
+    auto txn = MakeTransaction({"A", "X"} /* read_set */, {}  /* write_set */);
+
+    // Note: this relies on metadata being updated synchronously, or the txn may abort.
+    // May break in future implementations
+    test_slogs[i]->SendTxn(txn);
+    auto txn_resp = test_slogs[i]->RecvTxnResult();
+    ASSERT_EQ(TransactionStatus::COMMITTED, txn_resp.status());
+    ASSERT_EQ(TransactionType::SINGLE_HOME, txn_resp.internal().type()); // used to be MH
+    ASSERT_EQ("valA", txn_resp.read_set().at("A"));
+    ASSERT_EQ("valX", txn_resp.read_set().at("X"));
+  }
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   google::InstallFailureSignalHandler();


### PR DESCRIPTION
- Workers are sent a txn holder, used to check counters with the remaster manager (this could also be used in other loops, I didn't make that change)
- CheckCounters is moved to being static and in the abstract RemasterManager, so that the worker isn't tied to the specific SimpleRemasterManager implementation
- Adds a e2e test