### PR TITLE
Fixed a bug on key creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM ubuntu:bionic AS runner
 
     WORKDIR /opt/slog
     COPY --from=builder /src/build/slog .
-    COPY --from=builder /src/examples/*.conf .
+    COPY --from=builder /src/examples/*.conf ./
     COPY --from=builder /src/tools/ tools/
 
     RUN if [ -z "$SLOG_ONLY" ]; then \

--- a/common/types.h
+++ b/common/types.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <string>
 
+#include "common/constants.h"
 #include "proto/transaction.pb.h"
 
 using namespace std::chrono;
@@ -23,8 +24,8 @@ struct Metadata {
     counter = metadata.counter();
   }
 
-  uint32_t master;
-  uint32_t counter;
+  uint32_t master = DEFAULT_MASTER_REGION_OF_NEW_KEY;
+  uint32_t counter = 0;
 };
 
 struct Record {

--- a/module/scheduler_components/remaster_manager.h
+++ b/module/scheduler_components/remaster_manager.h
@@ -86,7 +86,9 @@ public:
         return VerifyMasterResult::WAITING;
       } else {
         CHECK(txn_master_metadata.at(key).master() == record.metadata.master)
-          << "Masters don't match for same key \"" << key << "\"";
+            << "Masters don't match for same key \"" << key
+            << "\". In txn: " << txn_master_metadata.at(key).master()
+            << ". In storage: " << record.metadata.master;
       }
     }
     return VerifyMasterResult::VALID;

--- a/tools/admin.py
+++ b/tools/admin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 """Admin tool
 
-This tool is used to automate controlling a cluster of SLOG servers with tasks
+This tool is used to control a cluster of SLOG servers with tasks
 such as starting a cluster, stopping a cluster, getting status, and more.
 """
 import docker


### PR DESCRIPTION
Found this bug happened when a new key was inserted. The `master` field in Metadata struct was not initialized so it contained garbage when this struct was created via default constructor in `RemasterManager::CheckCounters`. It then failed the CHECK for masters.