### PR TITLE
Update transaction holder with involved partitions

### DIFF
--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -238,6 +238,7 @@ bool operator==(const Transaction& txn1, const Transaction txn2) {
 
 std::ostream& operator<<(std::ostream& os, const MasterMetadata& metadata) {
   os << std::setw(10) << "(" << metadata.master() << ", " << metadata.counter() << ")";
+  return os;
 }
 
 } // namespace slog

--- a/common/transaction_holder.cpp
+++ b/common/transaction_holder.cpp
@@ -18,7 +18,7 @@ void ExtractKeyPartitions(
     ConfigurationPtr config,
     const Transaction& txn) {
   for (const auto& kv : txn.read_set()) {
-    partition_participants.emplace(config->GetPartitionOfKey(kv.first));
+    partition_participants.insert(config->GetPartitionOfKey(kv.first));
     // If this key is also in write_set, give it write lock instead
     if (config->KeyIsInLocalPartition(kv.first) 
         && !txn.write_set().contains(kv.first)) {
@@ -26,7 +26,7 @@ void ExtractKeyPartitions(
     }
   }
   for (const auto& kv : txn.write_set()) {
-    partition_participants.emplace(config->GetPartitionOfKey(kv.first));
+    partition_participants.insert(config->GetPartitionOfKey(kv.first));
     if (config->KeyIsInLocalPartition(kv.first)) {
       keys.emplace_back(kv.first, LockMode::WRITE);
     }

--- a/common/transaction_holder.cpp
+++ b/common/transaction_holder.cpp
@@ -5,17 +5,20 @@
 using std::pair;
 using std::make_pair;
 using std::vector;
+using std::unordered_set;
 using std::string;
 
 namespace slog {
 
 namespace {
 
-void ExtractKeysInPartition(
+void ExtractKeyPartitions(
     vector<std::pair<Key, LockMode>>& keys,
+    unordered_set<uint32_t>& partition_participants,
     ConfigurationPtr config,
     const Transaction& txn) {
   for (const auto& kv : txn.read_set()) {
+    partition_participants.emplace(config->GetPartitionOfKey(kv.first));
     // If this key is also in write_set, give it write lock instead
     if (config->KeyIsInLocalPartition(kv.first) 
         && !txn.write_set().contains(kv.first)) {
@@ -23,6 +26,7 @@ void ExtractKeysInPartition(
     }
   }
   for (const auto& kv : txn.write_set()) {
+    partition_participants.emplace(config->GetPartitionOfKey(kv.first));
     if (config->KeyIsInLocalPartition(kv.first)) {
       keys.emplace_back(kv.first, LockMode::WRITE);
     }
@@ -41,7 +45,8 @@ TransactionHolder::~TransactionHolder() {
 }
 
 void TransactionHolder::SetTransaction(const ConfigurationPtr config, Transaction* txn) {
-  ExtractKeysInPartition(keys_in_partition_, config, *txn);
+  // TODO: partition_participants_ is only needed by MH and SH, could avoid computing for LO
+  ExtractKeyPartitions(keys_in_partition_, partition_participants_, config, *txn);
   txn_ = txn;
 }
 
@@ -67,6 +72,10 @@ const vector<pair<Key, LockMode>>& TransactionHolder::KeysInPartition() const {
   return keys_in_partition_;
 }
 
+const std::unordered_set<uint32_t>& TransactionHolder::PartitionParticipants() const {
+  return partition_participants_;
+}
+
 vector<internal::Request>& TransactionHolder::EarlyRemoteReads() {
   return early_remote_reads_;
 }
@@ -76,7 +85,10 @@ uint32_t TransactionHolder::GetReplicaId() const {
 }
 
 uint32_t TransactionHolder::GetReplicaId(Transaction* txn) {
-  if (txn->internal().master_metadata().empty()) { // This should only be the case for testing
+  // Note that this uses all metadata, not just keys in partition. This shouldn't be empty,
+  // except for in testing.
+  // TODO: make this fatal, add metadata to tests
+  if (txn->internal().master_metadata().empty()) {
     LOG(WARNING) << "Master metadata empty: txn id " << txn->internal().id();
     return 0;
   }

--- a/common/transaction_holder.h
+++ b/common/transaction_holder.h
@@ -24,7 +24,7 @@ public:
   const std::string& GetWorker() const;
 
   const std::vector<std::pair<Key, LockMode>>& KeysInPartition() const;
-  const std::unordered_set<uint32_t>& PartitionParticipants() const;
+  const std::unordered_set<uint32_t>& InvolvedPartitions() const;
 
   std::vector<internal::Request>& EarlyRemoteReads();
 
@@ -46,7 +46,7 @@ private:
   string worker_;
   std::vector<internal::Request> early_remote_reads_;
   std::vector<std::pair<Key, LockMode>> keys_in_partition_;
-  std::unordered_set<uint32_t> partition_participants_;
+  std::unordered_set<uint32_t> involved_partitions_;
 };
 
 } // namespace slog

--- a/common/transaction_holder.h
+++ b/common/transaction_holder.h
@@ -24,6 +24,7 @@ public:
   const std::string& GetWorker() const;
 
   const std::vector<std::pair<Key, LockMode>>& KeysInPartition() const;
+  const std::unordered_set<uint32_t>& PartitionParticipants() const;
 
   std::vector<internal::Request>& EarlyRemoteReads();
 
@@ -45,6 +46,7 @@ private:
   string worker_;
   std::vector<internal::Request> early_remote_reads_;
   std::vector<std::pair<Key, LockMode>> keys_in_partition_;
+  std::unordered_set<uint32_t> partition_participants_;
 };
 
 } // namespace slog

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -308,12 +308,9 @@ void Scheduler::ProcessStatsRequest(const internal::StatsRequest& stats_request)
 ***********************************************/
 
 void Scheduler::HandleResponseFromWorker(const internal::WorkerResponse& res) {
-  if (!res.has_txn_id()) {
-    return;
-  }
-
-  // This txn is done so remove it from the txn list
   auto txn_id = res.txn_id();
+  auto txn_holder = all_txns_[txn_id];
+  auto txn = txn_holder.GetTransaction();
 
   // Release locks held by this txn. Enqueue the txns that
   // become ready thanks to this release.
@@ -321,8 +318,11 @@ void Scheduler::HandleResponseFromWorker(const internal::WorkerResponse& res) {
   for (auto unblocked_txn : unblocked_txns) {
     DispatchTransaction(unblocked_txn);
   }
-  auto txn = all_txns_[txn_id].ReleaseTransaction();
-  all_txns_.erase(txn_id);
+
+  RecordTxnEvent(
+    config_,
+    txn->mutable_internal(),
+    TransactionEvent::RELEASE_LOCKS);
 
   // If a remaster transaction, trigger any unblocked txns
   if (txn->procedure_case() == Transaction::ProcedureCase::kNewMaster) {
@@ -330,43 +330,36 @@ void Scheduler::HandleResponseFromWorker(const internal::WorkerResponse& res) {
     auto counter = txn->internal().master_metadata().at(key).master() + 1;
     auto remaster_result = remaster_manager_.RemasterOccured(key, counter);
 
-    for (auto txn_holder : remaster_result.unblocked) {
-      SendToLockManager(txn_holder);
+    for (auto unblocked_txn_holder : remaster_result.unblocked) {
+      SendToLockManager(unblocked_txn_holder);
     }
-    for (auto txn_holder : remaster_result.should_abort) {
-      AbortTransaction(txn_holder);
+    for (auto unblocked_txn_holder : remaster_result.should_abort) {
+      AbortTransaction(unblocked_txn_holder);
     }
+  }
+
+  // Send the txn back to the coordinating server
+  auto coordinating_server = MakeMachineIdAsString(
+      txn->internal().coordinating_server());
+  Request req;
+  auto completed_sub_txn = req.mutable_completed_subtxn();
+  completed_sub_txn->set_allocated_txn(txn);
+  completed_sub_txn->set_partition(config_->GetLocalPartition());
+  for (auto p : txn_holder.PartitionParticipants()) {
+    completed_sub_txn->add_involved_partitions(p);
   }
 
   RecordTxnEvent(
       config_,
       txn->mutable_internal(),
-      TransactionEvent::RELEASE_LOCKS);
+      TransactionEvent::EXIT_SCHEDULER);
 
-  // Send the txn back to the coordinating server if need to
-  auto local_partition = config_->GetLocalPartition();
-  auto& participants = res.participants();
-  if (std::find(
-      participants.begin(),
-      participants.end(),
-      local_partition) != participants.end()) {
-    auto coordinating_server = MakeMachineIdAsString(
-        txn->internal().coordinating_server());
-    Request req;
-    auto completed_sub_txn = req.mutable_completed_subtxn();
-    completed_sub_txn->set_allocated_txn(txn);
-    completed_sub_txn->set_partition(config_->GetLocalPartition());
-    for (auto p : participants) {
-      completed_sub_txn->add_involved_partitions(p);
-    }
+  Send(req, coordinating_server, SERVER_CHANNEL);
 
-    RecordTxnEvent(
-        config_,
-        txn->mutable_internal(),
-        TransactionEvent::EXIT_SCHEDULER);
-
-    Send(req, coordinating_server, SERVER_CHANNEL);
-  }
+  // This txn holder is done so remove it. The request
+  // will delete the txn
+  txn_holder.ReleaseTransaction();
+  all_txns_.erase(txn_id);
 }
 
 /***********************************************

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -343,7 +343,7 @@ void Scheduler::HandleResponseFromWorker(const internal::WorkerResponse& res) {
   auto completed_sub_txn = req.mutable_completed_subtxn();
   completed_sub_txn->set_allocated_txn(txn);
   completed_sub_txn->set_partition(config_->GetLocalPartition());
-  for (auto p : txn_holder.PartitionParticipants()) {
+  for (auto p : txn_holder.InvolvedPartitions()) {
     completed_sub_txn->add_involved_partitions(p);
   }
 

--- a/module/scheduler_components/worker.cpp
+++ b/module/scheduler_components/worker.cpp
@@ -125,7 +125,6 @@ TransactionState& Worker::InitializeTransactionState(TransactionHolder* txn_hold
   for (auto& key_value : *txn->mutable_read_set()) {
     const auto& key = key_value.first;
     auto partition = config_->GetPartitionOfKey(key);
-    state.partitions.insert(partition);
     if (partition == local_partition) {
       state.has_local_reads = true;
     } else {
@@ -144,7 +143,6 @@ TransactionState& Worker::InitializeTransactionState(TransactionHolder* txn_hold
   for (auto& key_value : *txn->mutable_write_set()) {
     const auto& key = key_value.first;
     auto partition = config_->GetPartitionOfKey(key);
-    state.partitions.insert(partition);
     if (partition == local_partition) {
       state.has_local_writes = true;
     } else {
@@ -225,13 +223,7 @@ void Worker::ExecuteAndCommitTransaction(TxnId txn_id) {
 
   // Response back to the scheduler
   Response res;
-  res.mutable_worker()->set_has_txn_id(true);
   res.mutable_worker()->set_txn_id(txn_id);
-  for (auto p : state.partitions) {
-    res.mutable_worker()
-        ->mutable_participants()
-        ->Add(p);
-  }
 
   RecordTxnEvent(
       config_,

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -31,7 +31,6 @@ struct TransactionState {
   // reads from all passive partitions
   unordered_set<uint32_t> remote_passive_partitions;
   unordered_set<uint32_t> remote_active_partitions;
-  unordered_set<uint32_t> partitions;
 };
 
 class Worker : public Module {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -175,9 +175,7 @@ message PaxosCommitResponse {
 }
 
 message WorkerResponse {
-    bool has_txn_id = 1;
     uint32 txn_id = 2;
-    repeated uint32 participants = 3;
 }
 
 message StatsResponse {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,8 @@ set(ALL_TESTS
   server_test
   sequencer_test
   simple_remaster_manager_test
-  string_utils_test)
+  string_utils_test
+  transaction_holder_test)
 
 add_executable(batch_log_test data_structure/batch_log_test.cpp)
 target_link_libraries(batch_log_test batch_log proto)
@@ -76,6 +77,9 @@ target_link_libraries(simple_remaster_manager_test test_utils)
 
 add_executable(string_utils_test common/string_utils_test.cpp)
 target_link_libraries(string_utils_test string_utils)
+
+add_executable(transaction_holder_test common/transaction_holder_test.cpp)
+target_link_libraries(transaction_holder_test common test_utils)
 
 foreach(TEST ${ALL_TESTS})
   target_link_libraries(${TEST} ${EXTERNAL_LIBS} GTest::GTest GTest::Main)

--- a/test/common/proto_utils_test.cpp
+++ b/test/common/proto_utils_test.cpp
@@ -8,8 +8,6 @@ using namespace slog;
 using internal::Request;
 using internal::Response;
 
-const string TEST_STRING = "test";
-
 TEST(ProtoUtilsTest, MachineIdStringToMachineId) {
   internal::MachineId mid;
 

--- a/test/common/transaction_holder_test.cpp
+++ b/test/common/transaction_holder_test.cpp
@@ -56,7 +56,7 @@ TEST_F(TransactionHolderTest, KeysInPartition) {
   ASSERT_TRUE(holder2.KeysInPartition().empty());
 }
 
-TEST_F(TransactionHolderTest, PartitionParticipants) {
+TEST_F(TransactionHolderTest, InvolvedPartitions) {
   for (uint32_t i = 0; i < NUM_MACHINES; i++) {
     auto txn = MakeTransaction(
       {"A"}, /* read_set */
@@ -66,7 +66,7 @@ TEST_F(TransactionHolderTest, PartitionParticipants) {
     txn->mutable_internal()->set_id(100);
 
     auto holder = TransactionHolder(configs[i], txn);
-    auto partitions = holder.PartitionParticipants();
+    auto partitions = holder.InvolvedPartitions();
     ASSERT_EQ(partitions.size(), 2);
     ASSERT_TRUE(partitions.count(0));
     ASSERT_TRUE(partitions.count(2));

--- a/test/common/transaction_holder_test.cpp
+++ b/test/common/transaction_holder_test.cpp
@@ -1,0 +1,74 @@
+#include <gmock/gmock.h>
+
+#include "common/transaction_holder.h"
+#include "common/proto_utils.h"
+#include "common/test_utils.h"
+
+using namespace std;
+using namespace slog;
+
+using ::testing::ElementsAre;
+
+class TransactionHolderTest : public ::testing::Test {
+protected:
+  static const size_t NUM_MACHINES = 6;
+  void SetUp() {
+    configs = MakeTestConfigurations(
+        "txn_holder",
+        2 /* num_replicas */,
+        3 /* num_partitions */);
+
+    /* 
+    Partition 0: A, D, Y
+    Partition 1: C, F, X
+    Partition 2: B, E, Z
+    */
+  }
+
+  ConfigVec configs;
+};
+
+TEST_F(TransactionHolderTest, TxnReplicaId) {
+  auto txn = MakeTransaction(
+      {"A"}, /* read_set */
+      {"D"},  /* write_set */
+      "", /* code */
+      {{"A", {1, 3}}, {"D", {1,0}}}); /* metadata */
+  txn->mutable_internal()->set_id(100);
+
+  auto holder = TransactionHolder(configs[0], txn);
+  ASSERT_EQ(holder.GetTransactionIdReplicaIdPair(), make_pair(100u, 1u));
+}
+
+TEST_F(TransactionHolderTest, KeysInPartition) {
+  auto txn = MakeTransaction(
+      {"A"}, /* read_set */
+      {"D"},  /* write_set */
+      "", /* code */
+      {{"A", {1, 3}}, {"D", {1,0}}}); /* metadata */
+  txn->mutable_internal()->set_id(100);
+
+  auto holder1 = TransactionHolder(configs[0], txn);
+  ASSERT_THAT(holder1.KeysInPartition(),
+    ElementsAre(make_pair("A", LockMode::READ), make_pair("D", LockMode::WRITE)));
+
+  auto holder2 = TransactionHolder(configs[1], holder1.ReleaseTransaction());
+  ASSERT_TRUE(holder2.KeysInPartition().empty());
+}
+
+TEST_F(TransactionHolderTest, PartitionParticipants) {
+  for (auto i = 0; i < NUM_MACHINES; i++) {
+    auto txn = MakeTransaction(
+      {"A"}, /* read_set */
+      {"B", "D"},  /* write_set */
+      "", /* code */
+      {{"A", {1, 3}}, {"B", {1,0}}, {"A", {1, 0}}}); /* metadata */
+    txn->mutable_internal()->set_id(100);
+
+    auto holder = TransactionHolder(configs[i], txn);
+    auto partitions = holder.PartitionParticipants();
+    ASSERT_EQ(partitions.size(), 2);
+    ASSERT_TRUE(partitions.count(0));
+    ASSERT_TRUE(partitions.count(2));
+  }
+}

--- a/test/common/transaction_holder_test.cpp
+++ b/test/common/transaction_holder_test.cpp
@@ -57,7 +57,7 @@ TEST_F(TransactionHolderTest, KeysInPartition) {
 }
 
 TEST_F(TransactionHolderTest, PartitionParticipants) {
-  for (auto i = 0; i < NUM_MACHINES; i++) {
+  for (uint32_t i = 0; i < NUM_MACHINES; i++) {
     auto txn = MakeTransaction(
       {"A"}, /* read_set */
       {"B", "D"},  /* write_set */


### PR DESCRIPTION
Hold participants information in the txn holder. This is used by the worker and will be used for aborts.