### PR TITLE
Multi-partiton aborts

### DIFF
--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -162,30 +162,30 @@ void MergeTransaction(Transaction& txn, const Transaction& other) {
     throw std::runtime_error(oss.str());
   }
   
-  auto MergeMap = [](auto this_set, const auto& other_set) {
-    for (const auto& key_value : other_set) {
-      const auto& key = key_value.first;
-      const auto& value = key_value.second;
-      if (this_set->contains(key)) {
-        if (this_set->at(key) != value) {
-          std::ostringstream oss;
-          oss << "Found conflicting value at key \"" << key << "\" while merging transactions. Val: "
-              << this_set->at(key) << ". Other val: " << value;
-          throw std::runtime_error(oss.str());
+  if (other.status() == TransactionStatus::ABORTED) {
+    txn.set_status(TransactionStatus::ABORTED);
+    txn.set_abort_reason(txn.abort_reason());
+  } else if (txn.status() != TransactionStatus::ABORTED) {
+    auto MergeMap = [](auto this_set, const auto& other_set) {
+      for (const auto& key_value : other_set) {
+        const auto& key = key_value.first;
+        const auto& value = key_value.second;
+        if (this_set->contains(key)) {
+          if (this_set->at(key) != value) {
+            std::ostringstream oss;
+            oss << "Found conflicting value at key \"" << key << "\" while merging transactions. Val: "
+                << this_set->at(key) << ". Other val: " << value;
+            throw std::runtime_error(oss.str());
+          }
+        } else {
+          this_set->insert(key_value);
         }
-      } else {
-        this_set->insert(key_value);
       }
-    }
-  };
-  MergeMap(txn.mutable_read_set(), other.read_set());
-  MergeMap(txn.mutable_write_set(), other.write_set());
-  txn.mutable_delete_set()->MergeFrom(other.delete_set());
-  
-  if (txn.status() != TransactionStatus::ABORTED) {
-    txn.set_status(other.status());
+    };
+    MergeMap(txn.mutable_read_set(), other.read_set());
+    MergeMap(txn.mutable_write_set(), other.write_set());
+    txn.mutable_delete_set()->MergeFrom(other.delete_set());
   }
-  txn.set_abort_reason(other.abort_reason());
 
   txn.mutable_internal()
       ->mutable_events()

--- a/common/proto_utils.cpp
+++ b/common/proto_utils.cpp
@@ -164,7 +164,7 @@ void MergeTransaction(Transaction& txn, const Transaction& other) {
   
   if (other.status() == TransactionStatus::ABORTED) {
     txn.set_status(TransactionStatus::ABORTED);
-    txn.set_abort_reason(txn.abort_reason());
+    txn.set_abort_reason(other.abort_reason());
   } else if (txn.status() != TransactionStatus::ABORTED) {
     auto MergeMap = [](auto this_set, const auto& other_set) {
       for (const auto& key_value : other_set) {

--- a/common/transaction_holder.cpp
+++ b/common/transaction_holder.cpp
@@ -10,31 +10,6 @@ using std::string;
 
 namespace slog {
 
-namespace {
-
-void ExtractKeyPartitions(
-    vector<std::pair<Key, LockMode>>& keys,
-    unordered_set<uint32_t>& partitions,
-    ConfigurationPtr config,
-    const Transaction& txn) {
-  for (const auto& kv : txn.read_set()) {
-    partitions.insert(config->GetPartitionOfKey(kv.first));
-    // If this key is also in write_set, give it write lock instead
-    if (config->KeyIsInLocalPartition(kv.first) 
-        && !txn.write_set().contains(kv.first)) {
-      keys.emplace_back(kv.first, LockMode::READ);
-    }
-  }
-  for (const auto& kv : txn.write_set()) {
-    partitions.insert(config->GetPartitionOfKey(kv.first));
-    if (config->KeyIsInLocalPartition(kv.first)) {
-      keys.emplace_back(kv.first, LockMode::WRITE);
-    }
-  }
-}
-
-} // namespace
-
 TransactionHolder::TransactionHolder() : txn_(nullptr), worker_("") {}
 TransactionHolder::TransactionHolder(ConfigurationPtr config, Transaction* txn) : worker_("") {
   SetTransaction(config, txn);
@@ -47,10 +22,25 @@ TransactionHolder::~TransactionHolder() {
 void TransactionHolder::SetTransaction(const ConfigurationPtr config, Transaction* txn) {
   keys_in_partition_.clear();
   involved_partitions_.clear();
+  active_partitions_.clear();
   involved_replicas_.clear();
 
   // TODO: involved_partitions_ is only needed by MH and SH, could avoid computing for LO
-  ExtractKeyPartitions(keys_in_partition_, involved_partitions_, config, *txn);
+  for (const auto& kv : txn->read_set()) {
+    involved_partitions_.insert(config->GetPartitionOfKey(kv.first));
+    // If this key is also in write_set, give it write lock instead
+    if (config->KeyIsInLocalPartition(kv.first) 
+        && !txn->write_set().contains(kv.first)) {
+      keys_in_partition_.emplace_back(kv.first, LockMode::READ);
+    }
+  }
+  for (const auto& kv : txn->write_set()) {
+    involved_partitions_.insert(config->GetPartitionOfKey(kv.first));
+    active_partitions_.insert(config->GetPartitionOfKey(kv.first));
+    if (config->KeyIsInLocalPartition(kv.first)) {
+      keys_in_partition_.emplace_back(kv.first, LockMode::WRITE);
+    }
+  }
 
   // TODO: only needed for MH
   for (auto& pair : txn->internal().master_metadata()) {
@@ -84,6 +74,10 @@ const vector<pair<Key, LockMode>>& TransactionHolder::KeysInPartition() const {
 
 const std::unordered_set<uint32_t>& TransactionHolder::InvolvedPartitions() const {
   return involved_partitions_;
+}
+
+const std::unordered_set<uint32_t>& TransactionHolder::ActivePartitions() const {
+  return active_partitions_;
 }
 
 const std::unordered_set<uint32_t>& TransactionHolder::InvolvedReplicas() const {

--- a/common/transaction_holder.cpp
+++ b/common/transaction_holder.cpp
@@ -50,6 +50,10 @@ void TransactionHolder::SetTransaction(const ConfigurationPtr config, Transactio
   txn_ = txn;
 }
 
+void TransactionHolder::SetTransactionNoProcessing(Transaction* txn) {
+  txn_ = txn;
+}
+
 Transaction* TransactionHolder::GetTransaction() const {
   return txn_;
 }

--- a/common/transaction_holder.h
+++ b/common/transaction_holder.h
@@ -25,6 +25,7 @@ public:
 
   const std::vector<std::pair<Key, LockMode>>& KeysInPartition() const;
   const std::unordered_set<uint32_t>& InvolvedPartitions() const;
+  const std::unordered_set<uint32_t>& ActivePartitions() const;
   const std::unordered_set<uint32_t>& InvolvedReplicas() const;
 
   std::vector<internal::Request>& EarlyRemoteReads();
@@ -48,6 +49,7 @@ private:
   std::vector<internal::Request> early_remote_reads_;
   std::vector<std::pair<Key, LockMode>> keys_in_partition_;
   std::unordered_set<uint32_t> involved_partitions_;
+  std::unordered_set<uint32_t> active_partitions_;
   std::unordered_set<uint32_t> involved_replicas_;
 };
 

--- a/common/transaction_holder.h
+++ b/common/transaction_holder.h
@@ -17,6 +17,7 @@ public:
   ~TransactionHolder();
 
   void SetTransaction(ConfigurationPtr config, Transaction* txn);
+  void SetTransactionNoProcessing(Transaction* txn);
   Transaction* GetTransaction() const;
   Transaction* ReleaseTransaction();
 

--- a/module/scheduler.cpp
+++ b/module/scheduler.cpp
@@ -239,7 +239,16 @@ void Scheduler::ProcessRemoteReadResult(
     // was already commited, it would be stuck in early_remote_reads forever.
     // Consider garbage collecting them if that happens.
     VLOG(2) << "Got early remote read result for txn " << txn_id;
+
+    auto remote_abort = req.remote_read_result().will_abort();
     holder.EarlyRemoteReads().emplace_back(move(req));
+
+    if (aborting_txns_.count(txn_id) > 0) {
+      // Check if this is the last required remote read
+      MaybeFinishAbort(txn_id);
+    } else if (remote_abort) {
+      TriggerPreDispatchAbort(txn_id);
+    }
   }
 }
 
@@ -331,16 +340,7 @@ void Scheduler::HandleResponseFromWorker(const internal::WorkerResponse& res) {
     ProcessRemasterResult(remaster_manager_.RemasterOccured(key, counter));
   }
 
-  switch (txn->status()) {
-    case TransactionStatus::COMMITTED:
-      SendToCoordinatingServer(txn_id);
-      break;
-    case TransactionStatus::ABORTED:
-      AbortTransaction(txn_id);
-      break;
-    default:
-      LOG(ERROR) << "Invalid txn status from worker: " << txn->status();
-  }
+  SendToCoordinatingServer(txn_id);
 }
 
 void Scheduler::SendToCoordinatingServer(TxnId txn_id) {
@@ -439,12 +439,16 @@ void Scheduler::MaybeProcessNextBatchesFromGlobalLog() {
             if (txn->procedure_case() == Transaction::ProcedureCase::kNewMaster) {
               auto past_master = txn->internal().master_metadata().begin()->second.master();
               if (txn->new_master() == past_master) {
-                AbortTransaction(txn_id);
+                TriggerPreDispatchAbort(txn_id);
                 break;
               }
             }
 
-            SendToRemasterManager(txn_holder);
+            if (aborting_txns_.count(txn_id)) {
+              AddTransactionToAbort(txn_id);
+            } else {
+              SendToRemasterManager(txn_holder);
+            }
             break;
           }
           case TransactionType::LOCK_ONLY: {
@@ -453,8 +457,8 @@ void Scheduler::MaybeProcessNextBatchesFromGlobalLog() {
                 << txn_replica_id.first <<", " << txn_replica_id.second;
             auto txn_holder = &lock_only_txns_[txn_replica_id];
 
-            if (mh_abort_waiting_on_.count(txn_id)) {
-              AbortLockOnlyTransaction(txn_replica_id);
+            if (aborting_txns_.count(txn_id)) {
+              AddLockOnlyTransactionToAbort(txn_replica_id);
             } else {
               SendToRemasterManager(txn_holder);
             }
@@ -464,8 +468,8 @@ void Scheduler::MaybeProcessNextBatchesFromGlobalLog() {
             VLOG(2) << "Accepted MULTI-HOME transaction " << txn_id;
             auto txn_holder = &all_txns_[txn_id];
 
-            if (mh_abort_waiting_on_.count(txn_id)) {
-              AbortTransaction(txn_id);
+            if (aborting_txns_.count(txn_id)) {
+              AddTransactionToAbort(txn_id);
             } else {
               SendToLockManager(txn_holder);
             }
@@ -528,12 +532,7 @@ void Scheduler::SendToRemasterManager(TransactionHolder* txn_holder) {
       break;
     }
     case VerifyMasterResult::ABORT: {
-      if (txn_type == TransactionType::LOCK_ONLY) {
-        AbortLockOnlyTransaction(txn_holder->GetTransactionIdReplicaIdPair());
-      } else {
-        AbortTransaction(txn->internal().id());
-      }
-      break;
+      TriggerPreDispatchAbort(txn->internal().id());
     }
     case VerifyMasterResult::WAITING: {
       // Do nothing
@@ -549,20 +548,12 @@ void Scheduler::ProcessRemasterResult(RemasterOccurredResult result) {
   for (auto unblocked_txn_holder : result.unblocked) {
     SendToLockManager(unblocked_txn_holder);
   }
+  unordered_set<TxnId> aborting_txn_ids;
   for (auto unblocked_txn_holder : result.should_abort) {
-    auto unblocked_txn_type = unblocked_txn_holder->GetTransaction()->internal().type();
-    switch (unblocked_txn_type) {
-      case TransactionType::SINGLE_HOME:
-        AbortTransaction(unblocked_txn_holder->GetTransaction()->internal().id());
-        break;
-      case TransactionType::LOCK_ONLY:
-        AbortLockOnlyTransaction(unblocked_txn_holder->GetTransactionIdReplicaIdPair());
-        break;
-      default:
-        // Mutli-home should not be sent to the remaster manager
-        LOG(ERROR) << "Invalid transaction type: " << unblocked_txn_type;
-        break;
-    }
+    aborting_txn_ids.insert(unblocked_txn_holder->GetTransaction()->internal().id());
+  }
+  for (auto txn_id : aborting_txn_ids) {
+    TriggerPreDispatchAbort(txn_id);
   }
 }
 
@@ -601,100 +592,73 @@ void Scheduler::SendToLockManager(const TransactionHolder* txn_holder) {
 }
 
 /***********************************************
-              Abort Processing
+         Pre-Dispatch Abort Processing
 ***********************************************/
 
+void Scheduler::TriggerPreDispatchAbort(TxnId txn_id) {
+  CHECK(aborting_txns_.count(txn_id) == 0) << "Abort was triggered twice: " << txn_id;
+  VLOG(2) << "Triggering abort of txn: " << txn_id;
 
-void Scheduler::AbortTransaction(TxnId txn_id) {
   auto& txn_holder = all_txns_[txn_id];
+  CHECK(txn_holder.GetWorker() == "")
+      << "Dispatched transactions are handled by the worker, txn " << txn_id;
+
+  aborting_txns_.insert(txn_id);
+
+  if (txn_holder.GetTransaction() != nullptr) {
+    AddTransactionToAbort(txn_id);
+  } else {
+    VLOG(3) << "Defering abort until txn arrives: " << txn_id;
+  }
+}
+
+void Scheduler::AddTransactionToAbort(TxnId txn_id) {
+  auto& txn_holder = all_txns_[txn_id];
+  auto txn = txn_holder.GetTransaction();
+  auto txn_type = txn->internal().type();
 
   if (txn_holder.InvolvedPartitions().size() > 1) {
     SendAbortToPartitions(txn_id);
   }
 
-  auto txn = txn_holder.GetTransaction();
-  VLOG(2) << "Aborting txn " << txn_id;
-  switch (txn->internal().type()) {
-    case TransactionType::SINGLE_HOME: {
-      // TODO: make sure read requests arriving after are deleted
-      txn->set_status(TransactionStatus::ABORTED);
-      SendToCoordinatingServer(txn_id);
-      break;
-    }
-    case TransactionType::MULTI_HOME: {
-      txn->set_status(TransactionStatus::ABORTED);
-
-      // If transaction has not been dispatched, then LOs must be collected
-      if (txn_holder.GetWorker() == "") {
-        auto& involved_replicas = txn_holder.InvolvedReplicas();
-        mh_abort_waiting_on_[txn_id] += involved_replicas.size();
-
-        // release LOs in remaster manager
-        ProcessRemasterResult(
-            remaster_manager_.ReleaseTransaction(txn_id, involved_replicas));
-
-        // release LOs in lock manager
-        for (auto unblocked_txn : lock_manager_.ReleaseLocks(txn_holder)) {
-          DispatchTransaction(unblocked_txn);
-        }
-
-        // Abort the LOs that have already arrived - the same that have been released
-        // from remaster and lock managers
-        for (auto replica : involved_replicas) {
-          auto txn_replica_id = std::make_pair(txn_id, replica);
-          if (lock_only_txns_.count(txn_replica_id)) {
-            lock_only_txns_.erase(txn_replica_id);
-            mh_abort_waiting_on_[txn_id] -= 1;
-          }
-        }
-
-        // Remove if all LOs have been received
-        if (mh_abort_waiting_on_[txn_id] == 0) {
-          mh_abort_waiting_on_.erase(txn_id);
-        }
-      }
-
-      // Can return abort even before all lock onlys are received
-      SendToCoordinatingServer(txn_id);
-      break;
-    }
-    case TransactionType::LOCK_ONLY: {
-      LOG(ERROR) << "LockOnly should not be sent to this method";
-      break;
-    }
-    default:
-      LOG(ERROR) << "Unknown transaction type";
-      break;
+  if (txn_type == TransactionType::MULTI_HOME) {
+    CollectLockOnlyTransactionsForAbort(txn_id);
   }
+
+  MaybeFinishAbort(txn_id);
 }
 
-void Scheduler::AbortLockOnlyTransaction(TxnIdReplicaIdPair txn_replica_id) {
-  // Check if the transaction has already been aborted. This can occur when
-  // Abort is called on the list of transactions returned by the remaster
-  // manager.
-  if (lock_only_txns_.count(txn_replica_id) == 0) {
-    return;
-  }
-  VLOG(2) << "Aborting lock-only txn " << txn_replica_id.first << ", " << txn_replica_id.second;
-  lock_only_txns_.erase(txn_replica_id);
+void Scheduler::AddLockOnlyTransactionToAbort(TxnIdReplicaIdPair txn_replica_id) {
+  auto& txn_holder = lock_only_txns_[txn_replica_id];
   auto txn_id = txn_replica_id.first;
 
-  // First part of the txn to abort, out of all LOs and MH
-  auto first_to_abort = (mh_abort_waiting_on_.count(txn_id) == 0);
-
-  // Update the number of LOs the abort is waiting on
+  lock_only_txns_.erase(txn_replica_id);
   mh_abort_waiting_on_[txn_id] -= 1;
-  if (mh_abort_waiting_on_[txn_id] == 0) {
-    CHECK(!all_txns_.count(txn_id)) << "Satisfied final abort condition while MH still present";
-    mh_abort_waiting_on_.erase(txn_id);
+  MaybeFinishAbort(txn_id);
+}
+
+void Scheduler::CollectLockOnlyTransactionsForAbort(TxnId txn_id) {
+  auto& txn_holder = all_txns_[txn_id];
+  auto& involved_replicas = txn_holder.InvolvedReplicas();
+  mh_abort_waiting_on_[txn_id] += involved_replicas.size();
+
+  // release LOs in remaster manager
+  ProcessRemasterResult(
+      remaster_manager_.ReleaseTransaction(txn_id, involved_replicas));
+
+  // release LOs in lock manager
+  for (auto unblocked_txn : lock_manager_.ReleaseLocks(txn_holder)) {
+    DispatchTransaction(unblocked_txn);
   }
 
-  // If the abort is started, the MH should have been deleted
-  CHECK(first_to_abort || !all_txns_.count(txn_id)) << "MH still present after full abort";
-
-  // Start the full abort
-  if (first_to_abort && all_txns_.count(txn_id)) {
-    AbortTransaction(txn_id);
+  // Erase the LOs that have already arrived - the same that have been released
+  // from remaster and lock managers
+  for (auto replica : involved_replicas) {
+    auto txn_replica_id = std::make_pair(txn_id, replica);
+    if (lock_only_txns_.count(txn_replica_id)) {
+      lock_only_txns_.erase(txn_replica_id);
+      mh_abort_waiting_on_[txn_id] -= 1;
+    }
   }
 }
 
@@ -712,6 +676,38 @@ void Scheduler::SendAbortToPartitions(TxnId txn_id) {
       SendSameChannel(request, machine_id);
     }
   }
+}
+
+void Scheduler::MaybeFinishAbort(TxnId txn_id) {
+  auto& txn_holder = all_txns_[txn_id];
+  auto txn = txn_holder.GetTransaction();
+
+  if (txn == nullptr) {
+    return;
+  }
+
+  auto num_remote_partitions = txn_holder.InvolvedPartitions().size() - 1;
+  auto local_partition = config_->GetLocalPartition();
+  auto local_partition_active =
+      (txn_holder.ActivePartitions().count(local_partition) > 0);
+  if (num_remote_partitions > 0 && local_partition_active) {
+    if (txn_holder.EarlyRemoteReads().size() < num_remote_partitions) {
+      return;
+    }
+  }
+
+  auto txn_type = txn->internal().type();
+  if (txn_type == TransactionType::MULTI_HOME) {
+    if (mh_abort_waiting_on_[txn_id] != 0) {
+      return;
+    } else {
+      mh_abort_waiting_on_.erase(txn_id);
+    }
+  }
+
+  txn->set_status(TransactionStatus::ABORTED);
+  aborting_txns_.erase(txn_id);
+  SendToCoordinatingServer(txn_id);
 }
 
 /***********************************************

--- a/module/scheduler.h
+++ b/module/scheduler.h
@@ -78,6 +78,7 @@ private:
   void DispatchTransaction(TxnId txn_id);
   void SendToWorker(internal::Request&& req, const string& worker);
 
+  void SendAbortToPartitions(TxnId txn_id);
   /**
    * Abort and return the transaction to the server.
    * Multi-Home transactions must also abort all associated Lock-Onlys. If the

--- a/module/scheduler_components/remaster_manager.h
+++ b/module/scheduler_components/remaster_manager.h
@@ -64,7 +64,7 @@ public:
 
   /**
    * Compare transaction metadata to stored metadata, without adding the
-   * transaciton to any queues
+   * transaction to any queues
    */
   static VerifyMasterResult CheckCounters(
       const TransactionHolder* txn_holder,

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -44,8 +44,8 @@ private:
 
   void ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
   
-  void ExecuteAndCommitTransaction(TxnId txn_id);
-  void ApplyWrites(TxnId txn_id);
+  void ExecuteAndMaybeCommitTransaction(TxnId txn_id);
+  void ExecuteAndMaybeCommitTransactionHelper(TxnId txn_id);
 
   void SendToScheduler(
       const google::protobuf::Message& req_or_res,

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -23,14 +23,7 @@ namespace slog {
 struct TransactionState {
   TransactionState() = default;
   TransactionState(TransactionHolder* txn_holder) : txn_holder(txn_holder) {}
-
   TransactionHolder* txn_holder;
-  bool has_local_reads;
-  bool has_local_writes;
-  // This set is reduced until we receive remote
-  // reads from all passive partitions
-  unordered_set<uint32_t> remote_passive_partitions;
-  unordered_set<uint32_t> remote_active_partitions;
   uint32_t remote_reads_waiting_on;
 };
 
@@ -52,7 +45,7 @@ private:
   void ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
   
   void ExecuteAndCommitTransaction(TxnId txn_id);
-  void ExecuteTransactionHelper(TxnId txn_id);
+  void ApplyWrites(TxnId txn_id);
 
   void SendToScheduler(
       const google::protobuf::Message& req_or_res,

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -31,6 +31,7 @@ struct TransactionState {
   // reads from all passive partitions
   unordered_set<uint32_t> remote_passive_partitions;
   unordered_set<uint32_t> remote_active_partitions;
+  uint32_t remote_reads_waiting_on;
 };
 
 class Worker : public Module {

--- a/proto/internal.proto
+++ b/proto/internal.proto
@@ -120,6 +120,7 @@ message RemoteReadResult {
     uint32 txn_id = 1;
     uint32 partition = 2;
     map<string, string> reads = 3;
+    bool will_abort = 4;
 }
 
 message CompletedSubtransaction {


### PR DESCRIPTION
> The scheduler portion is probably easiest to read by looking at the abort methods in the raw file, the diff is a bit jumbled

Added MP aborts and refactored abort logic. I think it's easier to follow now.

All partitions now send remote reads to the active partitions (instead of just those with reads). Remote reads can be flagged as aborts.

In the worker (completely handles post-dispatch aborts):
- checks counters, include the result in remote read sent to every active partition
- if active partition, wait for all remote reads
- if either of above were abort, return abort to scheduler

In scheduler (only handles pre-dispatch aborts):
- Abort triggered either by counter fail or early remote read with abort
- Abort sent to server and other partitions as soon as main txn arrives (SH or MH)
- once all lock-onlys and remote reads arrive, clean up