### PR TITLE
Simplify Server with custom sockets in BasicModule

### DIFF
--- a/common/test_utils.cpp
+++ b/common/test_utils.cpp
@@ -93,8 +93,7 @@ void TestSlog::Data(Key&& key, Record&& record) {
 }
 
 void TestSlog::AddServerAndClient() {
-  server_ = MakeRunnerFor<Server>(
-      config_, *context_, broker_, storage_);
+  server_ = MakeRunnerFor<Server>(config_, broker_, storage_);
 }
 
 void TestSlog::AddForwarder() {

--- a/examples/read_mh.json
+++ b/examples/read_mh.json
@@ -1,13 +1,5 @@
 {
   "read_set": ["A", "B", "C", "D", "E", "F"],
   "write_set": [],
-  "code": "GET A GET B GET C GET D GET E GET F",
-  "metadata": {
-    "A": 0,
-    "B": 0,
-    "C": 0,
-    "D": 1,
-    "E": 1,
-    "F": 1
-  }
+  "code": "GET A GET B GET C GET D GET E GET F"
 }

--- a/examples/write_mh.json
+++ b/examples/write_mh.json
@@ -1,13 +1,5 @@
 {
   "read_set": [],
   "write_set": ["A", "B", "C", "D", "E", "F"],
-  "code": "SET A Hello SET B World SET C !!!!! SET D Goodbye SET E World SET F ??????",
-  "metadata": {
-    "A": 0,
-    "B": 0,
-    "C": 0,
-    "D": 1,
-    "E": 1,
-    "F": 1
-  }
+  "code": "SET A Hello SET B World SET C !!!!! SET D Goodbye SET E World SET F ??????"
 }

--- a/module/base/basic_module.cpp
+++ b/module/base/basic_module.cpp
@@ -23,6 +23,10 @@ vector<zmq::socket_t> BasicModule::InitializeCustomSockets() {
   return {};
 }
 
+zmq::socket_t& BasicModule::GetCustomSocket(size_t i) {
+  return custom_sockets_[i];
+}
+
 void BasicModule::SetUp() {
   custom_sockets_ = InitializeCustomSockets();
   for (auto& socket : custom_sockets_) {

--- a/module/base/basic_module.h
+++ b/module/base/basic_module.h
@@ -35,6 +35,8 @@ protected:
       const MMessage& /* msg */,
       size_t /* socket_index */) {};
 
+  zmq::socket_t& GetCustomSocket(size_t i);
+
 private:
   void SetUp() final;
   void Loop() final;

--- a/service/slog.cpp
+++ b/service/slog.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[]) {
 
   // Create the server module. This is not added to the "modules" 
   // list below because it starts differently.
-  auto server = MakeRunnerFor<slog::Server>(config, *context, broker, storage);
+  auto server = MakeRunnerFor<slog::Server>(config, broker, storage);
 
   vector<unique_ptr<slog::ModuleRunner>> modules;
   modules.push_back(

--- a/test/module/server_test.cpp
+++ b/test/module/server_test.cpp
@@ -16,7 +16,6 @@ using namespace std;
 using namespace slog;
 
 TEST(ServerTest, LookupMaster) {
-  const string REQUESTER_CHANNEL("requester");
   auto configs = MakeTestConfigurations("lookup", 1, 1, 23 /* seed */);
   TestSlog test_slog(configs[0]);
   test_slog.AddServerAndClient();
@@ -24,7 +23,7 @@ TEST(ServerTest, LookupMaster) {
   test_slog.Data("B", {"fbczx", 1, 1});
   test_slog.Data("C", {"bzxcv", 2, 2});
   unique_ptr<Channel> requester(
-      test_slog.AddChannel(REQUESTER_CHANNEL));
+      test_slog.AddChannel(FORWARDER_CHANNEL));
   test_slog.StartInNewThreads();
 
   // Send a lookup request to the server
@@ -36,7 +35,7 @@ TEST(ServerTest, LookupMaster) {
   lookup->add_keys("D");
   MMessage msg;
   msg.Set(MM_PROTO, req);
-  msg.Set(MM_FROM_CHANNEL, REQUESTER_CHANNEL);
+  msg.Set(MM_FROM_CHANNEL, FORWARDER_CHANNEL);
   msg.Set(MM_TO_CHANNEL, SERVER_CHANNEL);
   requester->Send(msg);
 


### PR DESCRIPTION
`Server` wasn't extended from `BasicModule` because it needed another socket for the client. `BasicModule` now supports custom sockets so using it simplifies the code. 