### PR TITLE
Refactor worker 

### DIFF
--- a/module/scheduler_components/commands.cpp
+++ b/module/scheduler_components/commands.cpp
@@ -16,7 +16,7 @@ const string SPACE(" \t\n\v\f\r");
 
 const std::unordered_map<string, size_t>
 KeyValueCommands::COMMAND_NUM_ARGS = {
-  {"GET", 1}, {"SET", 2}, {"DEL", 1}, {"COPY", 2}
+  {"GET", 1}, {"SET", 2}, {"DEL", 1}, {"COPY", 2}, {"ABORT", 1}
 };
 
 void KeyValueCommands::Execute(Transaction& txn) {
@@ -40,6 +40,8 @@ void KeyValueCommands::Execute(Transaction& txn) {
       if (read_set.contains(src) && write_set.contains(dst)) {
         write_set[dst] = read_set.at(src);
       }
+    } else if (cmd_ == "ABORT") {
+      Abort() << "User abort (key: " << args_[0] << ")";
     }
   }
 

--- a/module/scheduler_components/commands.cpp
+++ b/module/scheduler_components/commands.cpp
@@ -41,7 +41,7 @@ void KeyValueCommands::Execute(Transaction& txn) {
         write_set[dst] = read_set.at(src);
       }
     } else if (cmd_ == "ABORT") {
-      if (write_set.contains(args_[0]) || read_set.contains(args_[1])) {
+      if (write_set.contains(args_[0]) || read_set.contains(args_[0])) {
         Abort() << "User abort (key: " << args_[0] << ")";
       }
     }

--- a/module/scheduler_components/commands.cpp
+++ b/module/scheduler_components/commands.cpp
@@ -41,7 +41,9 @@ void KeyValueCommands::Execute(Transaction& txn) {
         write_set[dst] = read_set.at(src);
       }
     } else if (cmd_ == "ABORT") {
-      Abort() << "User abort (key: " << args_[0] << ")";
+      if (write_set.contains(args_[0]) || read_set.contains(args_[1])) {
+        Abort() << "User abort (key: " << args_[0] << ")";
+      }
     }
   }
 

--- a/module/scheduler_components/worker.cpp
+++ b/module/scheduler_components/worker.cpp
@@ -263,8 +263,8 @@ void Worker::ReadLocalStorage(TxnId txn_id) {
   SendToOtherPartitions(std::move(request), txn_holder->ActivePartitions());
 
   // TODO: if will_abort == true, we can immediate jump to the FINISH phased.
-  //       This requires removing the CHECK at the start of ProcessRemoteReadResult
-  //       because we're requiring a txn (aborted or not) to receive all remote reads
+  //       To do this, we need to removing the CHECK at the start of ProcessRemoteReadResult
+  //       because we no longer require an aborted txn to receive all remote reads
   //       before moving on.
   // Set the number of remote reads that this partition needs to wait for
   state.remote_reads_waiting_on = 0;

--- a/module/scheduler_components/worker.cpp
+++ b/module/scheduler_components/worker.cpp
@@ -9,7 +9,11 @@
 #include "common/proto_utils.h"
 #include "module/scheduler.h"
 
-#define FALLTHROUGH __attribute__((fallthrough))
+#ifdef __GNUC__
+#define FALLTHROUGH [[gnu::fallthrough]]
+#else
+#define FALLTHROUGH
+#endif
 
 namespace slog {
 

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -21,12 +21,25 @@ using std::unordered_set;
 namespace slog {
 
 struct TransactionState {
+  enum class Phase {
+    READ_LOCAL_STORAGE,
+    WAIT_REMOTE_READ,
+    EXECUTE,
+    WAIT_CONFIRMATION,
+    COMMIT,
+    FINISH,
+  };
+
   TransactionState() = default;
   TransactionState(TransactionHolder* txn_holder) : txn_holder(txn_holder) {}
-  TransactionHolder* txn_holder;
-  uint32_t remote_reads_waiting_on;
+  TransactionHolder* txn_holder = nullptr;
+  uint32_t remote_messages_waiting_on = 0;
+  Phase phase = Phase::READ_LOCAL_STORAGE;
 };
 
+/**
+ * 
+ */
 class Worker : public Module {
 public:
   Worker(
@@ -38,15 +51,18 @@ public:
   void Loop() final;
 
 private:
-  void ProcessWorkerRequest(const internal::WorkerRequest& req);
-  TransactionState& InitializeTransactionState(TransactionHolder* txn);
-  void PopulateDataFromLocalStorage(Transaction* txn);
+  TxnId ProcessWorkerRequest(const internal::WorkerRequest& req);
+  TxnId ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
+  void AdvanceTransaction(TxnId txn_id);
 
-  void ProcessRemoteReadResult(const internal::RemoteReadResult& read_result);
-  
-  void ExecuteAndMaybeCommitTransaction(TxnId txn_id);
-  void ExecuteAndMaybeCommitTransactionHelper(TxnId txn_id);
+  void ReadLocalStorage(TxnId txn_id);
+  void Execute(TxnId txn_id);
+  void Commit(TxnId txn_id);
+  void Finish(TxnId txn_id);
 
+  void SendToOtherPartitions(
+      internal::Request&& request,
+      const std::unordered_set<uint32_t>& partitions);
   void SendToScheduler(
       const google::protobuf::Message& req_or_res,
       string&& forward_to_machine = "");

--- a/module/scheduler_components/worker.h
+++ b/module/scheduler_components/worker.h
@@ -25,7 +25,6 @@ struct TransactionState {
     READ_LOCAL_STORAGE,
     WAIT_REMOTE_READ,
     EXECUTE,
-    WAIT_CONFIRMATION,
     COMMIT,
     FINISH,
   };
@@ -33,7 +32,7 @@ struct TransactionState {
   TransactionState() = default;
   TransactionState(TransactionHolder* txn_holder) : txn_holder(txn_holder) {}
   TransactionHolder* txn_holder = nullptr;
-  uint32_t remote_messages_waiting_on = 0;
+  uint32_t remote_reads_waiting_on = 0;
   Phase phase = Phase::READ_LOCAL_STORAGE;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(broker_and_sender_test connection/broker_and_sender_test.cpp)
 target_link_libraries(broker_and_sender_test test_utils)
 
 add_executable(commands_test module/scheduler_components/commands_test.cpp)
-target_link_libraries(commands_test test_utils)
+target_link_libraries(commands_test scheduler_components test_utils)
 
 add_executable(concurrent_hash_map_test data_structure/concurrent_hash_map_test.cpp)
 

--- a/test/e2e/e2e_test.cpp
+++ b/test/e2e/e2e_test.cpp
@@ -61,9 +61,9 @@ protected:
   ConfigVec configs;
 };
 
-This test submits multiple transactions to the system serially and checks the
-read values for correctness.
-TODO: submit transactions concurrently (multiple outcomes would be valid)
+// This test submits multiple transactions to the system serially and checks the
+// read values for correctness.
+// TODO: submit transactions concurrently (multiple outcomes would be valid)
 TEST_F(E2ETest, BasicSingleHomeSingleParition) {
   auto txn1 = MakeTransaction(
     {}, /* read_set */

--- a/test/e2e/e2e_test.cpp
+++ b/test/e2e/e2e_test.cpp
@@ -158,7 +158,7 @@ TEST_F(E2ETest, AbortTxn) {
   auto aborted_txn = MakeTransaction(
       {"A"}, /* read_set */
       {"B"},  /* write_set */
-      "SET B notB ABORT A", /* code */
+      "SET B notB EQ A notA", /* code */
       {}, /* master metadata */
       MakeMachineId("0:0") /* coordinating server */);
 


### PR DESCRIPTION
There are a lot of changes in this pr and it is quite hard to compare between the old and new code so I suggest just read the new code. Other than adding the ABORT command for explicitly aborting a transaction, this pr refactors the worker to make clearer the different phases that a transaction will go through. The code for each phase is put into its own well-defined method to make it easier to read and extend. The phases are:
```
READ_LOCAL_STORAGE,
WAIT_REMOTE_READ,
EXECUTE,
COMMIT,
FINISH,
```

`Worker::ProcessWorkerRequest` now only initializes the state of a new transaction.
`Worker::ProcessRemoteReadResult` is the same as before.

Both of these methods do not call other transaction processing methods but only create/change the state of a transaction. 

`Worker::AdvanceTransaction` is a new method, which calls the appropriate transaction processing method based on a transaction's state. This method is called whenever a new message arrives at the worker.

