### PR TITLE
Command for spawning multiple benchmark clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ FROM ubuntu:bionic AS runner
 
     WORKDIR /opt/slog
     COPY --from=builder /src/build/slog .
+    COPY --from=builder /src/build/benchmark .
     COPY --from=builder /src/examples/*.conf ./
     COPY --from=builder /src/tools/ tools/
 

--- a/workload/workload_generator.h
+++ b/workload/workload_generator.h
@@ -74,7 +74,7 @@ private:
     while ((pos = NextToken(token, params_str, ";,", pos)) != std::string::npos) {
       auto eq_pos = token.find_first_of("=");
       if (eq_pos == std::string::npos) {
-        throw std::runtime_error("Invalid param entry: " + token);
+        throw std::runtime_error("Invalid workload param token: " + token);
       }
       auto key = Trim(token.substr(0, eq_pos));
       map[key] = Trim(token.substr(eq_pos + 1));


### PR DESCRIPTION
Example 
```
python tools/admin.py benchmark examples/cluster.conf --num-txns 1000 --clients clients.json --user ctring   
```
Most of other arguments are similar to those in the `benchmark` tool.

The `clients.json` file looks like this
```json
[
    [
        "192.168.2.11",
        "192.168.2.12",
        "192.168.2.13"
    ],
    [
        "192.168.2.14"
    ]
]
```
The machine addresses are put in separate lists corresponding to the region numbers so that we can tell the benchmark tool to sends txn to their neighboring servers.

Also modified the `logs` command to get logs from any machine without specifying a config file. We can view the logs from the benchmark machine like this:
```
python tools/admin.py logs -a 192.168.2.11 -u ctring --container benchmark
```

Note that the `gen_data` command is still reading from the config file so we cannot generate data on the machines in the `clients.json` file yet. We also need another command to fetch the benchmarking data. 